### PR TITLE
feat: support coomer.st domain

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/CoomerPartyRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/CoomerPartyRipper.java
@@ -32,7 +32,7 @@ public class CoomerPartyRipper extends AbstractJSONRipper {
     private static final Logger logger = LogManager.getLogger(CoomerPartyRipper.class);
 
     private String IMG_URL_BASE = "https://img.coomer.st";
-    private String VID_URL_BASE = "https://c1.coomer.st/data";
+    private String VID_URL_BASE = "https://c1.coomer.st";
     private static final Pattern IMG_PATTERN = Pattern.compile("^.*\\.(jpg|jpeg|png|gif|apng|webp|tif|tiff)$", Pattern.CASE_INSENSITIVE);
     private static final Pattern VID_PATTERN = Pattern.compile("^.*\\.(webm|mp4|m4v)$", Pattern.CASE_INSENSITIVE);
 
@@ -108,7 +108,7 @@ public class CoomerPartyRipper extends AbstractJSONRipper {
     private void setDomain(String newDomain) {
         domain = newDomain;
         IMG_URL_BASE = "https://img." + newDomain;
-        VID_URL_BASE = "https://c1." + newDomain + "/data";
+        VID_URL_BASE = "https://c1." + newDomain;
         POSTS_ENDPOINT = "https://" + newDomain + "/api/v1/%s/user/%s?o=%d";
     }
 
@@ -241,6 +241,16 @@ public class CoomerPartyRipper extends AbstractJSONRipper {
         }
     }
 
+    private String buildMediaUrl(String base, String path) {
+        if (!path.startsWith("/")) {
+            path = "/" + path;
+        }
+        if (!path.startsWith("/data/") && !path.startsWith("/thumbnail/") && !path.startsWith("/original/")) {
+            path = "/data" + path;
+        }
+        return base + path;
+    }
+
     private void pullFileUrl(JSONObject post, ArrayList<String> results) {
         if (post == null) {
             logger.warn("Attempted to parse null post object");
@@ -275,9 +285,9 @@ public class CoomerPartyRipper extends AbstractJSONRipper {
                     return;
                 }
             } else if (isImage(path)) {
-                url = IMG_URL_BASE + path;
+                url = buildMediaUrl(IMG_URL_BASE, path);
             } else if (isVideo(path)) {
-                url = VID_URL_BASE + path;
+                url = buildMediaUrl(VID_URL_BASE, path);
             } else {
                 logger.warn("Unsupported media extension in path: " + path);
                 return;

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/CoomerPartyRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/CoomerPartyRipper.java
@@ -268,15 +268,22 @@ public class CoomerPartyRipper extends AbstractJSONRipper {
             }
 
             String url;
-            if (isImage(path)) {
+            if (path.startsWith("http")) {
+                url = path;
+                if (!isImage(url) && !isVideo(url)) {
+                    logger.warn("Unsupported media extension in path: " + path);
+                    return;
+                }
+            } else if (isImage(path)) {
                 url = IMG_URL_BASE + path;
-                results.add(url);
             } else if (isVideo(path)) {
                 url = VID_URL_BASE + path;
-                results.add(url);
             } else {
                 logger.warn("Unsupported media extension in path: " + path);
+                return;
             }
+
+            results.add(url);
 
         } catch (JSONException e) {
             logger.error("Error parsing 'file' object from post: " + e.getMessage());

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/CoomerPartyRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/CoomerPartyRipper.java
@@ -31,7 +31,7 @@ public class CoomerPartyRipper extends AbstractJSONRipper {
 
     private static final Logger logger = LogManager.getLogger(CoomerPartyRipper.class);
 
-    private String IMG_URL_BASE = "https://c3.coomer.st/data";
+    private String IMG_URL_BASE = "https://img.coomer.st";
     private String VID_URL_BASE = "https://c1.coomer.st/data";
     private static final Pattern IMG_PATTERN = Pattern.compile("^.*\\.(jpg|jpeg|png|gif|apng|webp|tif|tiff)$", Pattern.CASE_INSENSITIVE);
     private static final Pattern VID_PATTERN = Pattern.compile("^.*\\.(webm|mp4|m4v)$", Pattern.CASE_INSENSITIVE);
@@ -107,7 +107,7 @@ public class CoomerPartyRipper extends AbstractJSONRipper {
 
     private void setDomain(String newDomain) {
         domain = newDomain;
-        IMG_URL_BASE = "https://c3." + newDomain + "/data";
+        IMG_URL_BASE = "https://img." + newDomain;
         VID_URL_BASE = "https://c1." + newDomain + "/data";
         POSTS_ENDPOINT = "https://" + newDomain + "/api/v1/%s/user/%s?o=%d";
     }

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/CoomerPartyRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/CoomerPartyRipper.java
@@ -246,7 +246,7 @@ public class CoomerPartyRipper extends AbstractJSONRipper {
             path = "/" + path;
         }
         if (!path.startsWith("/data/") && !path.startsWith("/thumbnail/") && !path.startsWith("/original/")) {
-            path = "/data" + path;
+            path = "/thumbnail/data" + path;
         }
         return base + path;
     }

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/CoomerPartyRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/CoomerPartyRipperTest.java
@@ -58,12 +58,12 @@ public class CoomerPartyRipperTest extends RippersTest {
     public void testAbsoluteFileUrl() throws Exception {
         URL base = new URI("https://coomer.st/onlyfans/user/soogsx").toURL();
         TestableCoomerRipper ripper = new TestableCoomerRipper(base);
-        JSONObject fileObj = new JSONObject().put("path", "https://c3.coomer.st/data/test.jpg");
+        JSONObject fileObj = new JSONObject().put("path", "https://img.coomer.st/thumbnail/data/test.jpg");
         JSONObject postObj = new JSONObject().put("file", fileObj);
         JSONArray posts = new JSONArray().put(postObj);
         JSONObject wrapper = new JSONObject().put("array", posts);
         List<String> urls = ripper.publicGetURLsFromJSON(wrapper);
         assertEquals(1, urls.size());
-        assertEquals("https://c3.coomer.st/data/test.jpg", urls.get(0));
+        assertEquals("https://img.coomer.st/thumbnail/data/test.jpg", urls.get(0));
     }
 }

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/CoomerPartyRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/CoomerPartyRipperTest.java
@@ -7,13 +7,26 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.List;
 
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.json.JSONArray;
+import org.json.JSONObject;
 
 import com.rarchives.ripme.ripper.rippers.CoomerPartyRipper;
 
 public class CoomerPartyRipperTest extends RippersTest {
+
+    private static class TestableCoomerRipper extends CoomerPartyRipper {
+        public TestableCoomerRipper(URL url) throws IOException {
+            super(url);
+        }
+
+        public List<String> publicGetURLsFromJSON(JSONObject json) {
+            return super.getURLsFromJSON(json);
+        }
+    }
     @Test
     @Tag("flaky")
     public void testRip() throws IOException, URISyntaxException {
@@ -39,5 +52,18 @@ public class CoomerPartyRipperTest extends RippersTest {
             assertTrue(ripper.canRip(url));
             assertEquals(expectedGid, ripper.getGID(url));
         }
+    }
+
+    @Test
+    public void testAbsoluteFileUrl() throws Exception {
+        URL base = new URI("https://coomer.st/onlyfans/user/soogsx").toURL();
+        TestableCoomerRipper ripper = new TestableCoomerRipper(base);
+        JSONObject fileObj = new JSONObject().put("path", "https://c3.coomer.st/data/test.jpg");
+        JSONObject postObj = new JSONObject().put("file", fileObj);
+        JSONArray posts = new JSONArray().put(postObj);
+        JSONObject wrapper = new JSONObject().put("array", posts);
+        List<String> urls = ripper.publicGetURLsFromJSON(wrapper);
+        assertEquals(1, urls.size());
+        assertEquals("https://c3.coomer.st/data/test.jpg", urls.get(0));
     }
 }

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/CoomerPartyRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/CoomerPartyRipperTest.java
@@ -66,4 +66,17 @@ public class CoomerPartyRipperTest extends RippersTest {
         assertEquals(1, urls.size());
         assertEquals("https://img.coomer.st/thumbnail/data/test.jpg", urls.get(0));
     }
+
+    @Test
+    public void testImagePathWithoutDataPrefix() throws Exception {
+        URL base = new URI("https://coomer.st/onlyfans/user/soogsx").toURL();
+        TestableCoomerRipper ripper = new TestableCoomerRipper(base);
+        JSONObject fileObj = new JSONObject().put("path", "/ab/cd/test.jpg");
+        JSONObject postObj = new JSONObject().put("file", fileObj);
+        JSONArray posts = new JSONArray().put(postObj);
+        JSONObject wrapper = new JSONObject().put("array", posts);
+        List<String> urls = ripper.publicGetURLsFromJSON(wrapper);
+        assertEquals(1, urls.size());
+        assertEquals("https://img.coomer.st/data/ab/cd/test.jpg", urls.get(0));
+    }
 }

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/CoomerPartyRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/CoomerPartyRipperTest.java
@@ -31,6 +31,7 @@ public class CoomerPartyRipperTest extends RippersTest {
                 "https://coomer.st/onlyfans/user/soogsx/", // with slash at the end
                 "https://coomer.st/onlyfans/user/soogsx?whatever=abc", // with url params
                 "https://coomer.party/onlyfans/user/soogsx", // alternate domain
+                "https://coomer.su/onlyfans/user/soogsx", // legacy domain
         };
         for (String stringUrl : urls) {
             URL url = new URI(stringUrl).toURL();


### PR DESCRIPTION
## Summary
- extend CoomerParty ripper to handle coomer.st and coomer.su hosts
- fallback to alternate domains if coomer.su is unreachable
- test URL parsing for new domains

## Testing
- `./gradlew test` *(fails: Could not resolve org.junit:junit-bom:5.10.0 (403 Forbidden))*


------
https://chatgpt.com/codex/tasks/task_e_688f78a3b6a4832da36ae3feedc75aa2