### PR TITLE
fix: update Coomer API endpoint

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/CoomerPartyRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/CoomerPartyRipper.java
@@ -17,6 +17,7 @@ import org.apache.logging.log4j.Logger;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.jsoup.HttpStatusException;
 
 import com.rarchives.ripme.ripper.AbstractJSONRipper;
 import com.rarchives.ripme.utils.Http;
@@ -43,8 +44,9 @@ public class CoomerPartyRipper extends AbstractJSONRipper {
     private static final String KEY_PATH = "path";
     private static final String KEY_ATTACHMENTS = "attachments";
 
-    // Posts Request Endpoint
-    private String POSTS_ENDPOINT = "https://coomer.st/api/v1/%s/user/%s?o=%d";
+    // Posts Request Endpoint templates
+    private static final String POSTS_ENDPOINT = "https://%s/api/v1/%s/user/%s/posts?o=%d";
+    private static final String LEGACY_POSTS_ENDPOINT = "https://%s/api/v1/%s/user/%s?o=%d";
 
     // Pagination is strictly 50 posts per page, per API schema.
     private Integer pageCount = 0;
@@ -107,41 +109,54 @@ public class CoomerPartyRipper extends AbstractJSONRipper {
 
     private void setDomain(String newDomain) {
         domain = newDomain;
-        IMG_URL_BASE = "https://img." + newDomain;
-        VID_URL_BASE = "https://c1." + newDomain;
-        POSTS_ENDPOINT = "https://" + newDomain + "/api/v1/%s/user/%s?o=%d";
+        IMG_URL_BASE = "https://" + newDomain;
+        VID_URL_BASE = "https://" + newDomain;
     }
 
     private JSONObject getJsonPostsForOffset(Integer offset) throws IOException {
         Set<String> domainsToTry = new LinkedHashSet<>();
         domainsToTry.add(domain);
+        domainsToTry.add("coomer.party");
         domainsToTry.add("coomer.su");
         domainsToTry.add("coomer.st");
+
+        List<String> endpointTemplates = Arrays.asList(POSTS_ENDPOINT, LEGACY_POSTS_ENDPOINT);
 
         IOException lastException = null;
         for (String dom : domainsToTry) {
             setDomain(dom);
-            String apiUrl = String.format(POSTS_ENDPOINT, service, user, offset);
-            try {
-                String jsonArrayString = Http.url(apiUrl)
-                        .ignoreContentType()
-                        .response()
-                        .body();
+            for (String endpoint : endpointTemplates) {
+                String apiUrl = String.format(endpoint, dom, service, user, offset);
+                try {
+                    String jsonArrayString = Http.url(apiUrl)
+                            .ignoreContentType()
+                            .response()
+                            .body();
 
-                logger.debug("Raw JSON from API for offset " + offset + ": " + jsonArrayString);
+                    logger.debug("Raw JSON from API for offset " + offset + ": " + jsonArrayString);
 
-                JSONArray jsonArray = new JSONArray(jsonArrayString);
+                    JSONArray jsonArray = new JSONArray(jsonArrayString);
 
-                if (jsonArray.isEmpty()) {
-                    logger.warn("No posts found at offset " + offset + " for user: " + user);
+                    if (jsonArray.isEmpty()) {
+                        logger.warn("No posts found at offset " + offset + " for user: " + user);
+                    }
+
+                    JSONObject wrapperObject = new JSONObject();
+                    wrapperObject.put(KEY_WRAPPER_JSON_ARRAY, jsonArray);
+                    return wrapperObject;
+                } catch (HttpStatusException e) {
+                    if (e.getStatusCode() == 400) {
+                        logger.info("Offset {} out of range for user {}, treating as no more posts", offset, user);
+                        JSONObject wrapperObject = new JSONObject();
+                        wrapperObject.put(KEY_WRAPPER_JSON_ARRAY, new JSONArray());
+                        return wrapperObject;
+                    }
+                    lastException = e;
+                    logger.warn("Failed to fetch posts from {}: {}", apiUrl, e.getMessage());
+                } catch (IOException e) {
+                    lastException = e;
+                    logger.warn("Failed to fetch posts from {}: {}", apiUrl, e.getMessage());
                 }
-
-                JSONObject wrapperObject = new JSONObject();
-                wrapperObject.put(KEY_WRAPPER_JSON_ARRAY, jsonArray);
-                return wrapperObject;
-            } catch (IOException e) {
-                lastException = e;
-                logger.warn("Failed to fetch posts from {}: {}", apiUrl, e.getMessage());
             }
         }
         throw lastException;
@@ -241,12 +256,12 @@ public class CoomerPartyRipper extends AbstractJSONRipper {
         }
     }
 
-    private String buildMediaUrl(String base, String path) {
+    private String buildMediaUrl(String base, String path, boolean isVideo) {
         if (!path.startsWith("/")) {
             path = "/" + path;
         }
         if (!path.startsWith("/data/") && !path.startsWith("/thumbnail/") && !path.startsWith("/original/")) {
-            path = "/thumbnail/data" + path;
+            path = (isVideo ? "/data" : "/thumbnail/data") + path;
         }
         return base + path;
     }
@@ -285,9 +300,9 @@ public class CoomerPartyRipper extends AbstractJSONRipper {
                     return;
                 }
             } else if (isImage(path)) {
-                url = buildMediaUrl(IMG_URL_BASE, path);
+                url = buildMediaUrl(IMG_URL_BASE, path, false);
             } else if (isVideo(path)) {
-                url = buildMediaUrl(VID_URL_BASE, path);
+                url = buildMediaUrl(VID_URL_BASE, path, true);
             } else {
                 logger.warn("Unsupported media extension in path: " + path);
                 return;


### PR DESCRIPTION
## Summary
- handle out-of-range responses from `/posts` endpoint by treating HTTP 400 as end-of-feed
- drop hardcoded media subdomains so redirects resolve correctly when downloading videos

## Testing
- `./gradlew assemble`
- `./gradlew test` *(fails: Could not resolve org.junit:junit-bom:5.10.0. Received status code 403)*

------
https://chatgpt.com/codex/tasks/task_e_689d88d1edec832dae2c99956ae21247