### PR TITLE
Handle non-JSON redirects in Coomer ripper

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/CoomerPartyRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/CoomerPartyRipper.java
@@ -130,6 +130,7 @@ public class CoomerPartyRipper extends AbstractJSONRipper {
                 try {
                     String jsonArrayString = Http.url(apiUrl)
                             .ignoreContentType()
+                            .header("Accept", "application/json")
                             .response()
                             .body();
 

--- a/src/main/java/com/rarchives/ripme/utils/Http.java
+++ b/src/main/java/com/rarchives/ripme/utils/Http.java
@@ -39,6 +39,7 @@ public class Http {
 
     private static final int TIMEOUT = Utils.getConfigInteger("page.timeout", 5 * 1000);
     private static final Logger logger = LogManager.getLogger(Http.class);
+    private static final String DEFAULT_ACCEPT_HEADER = "*/*";
 
     private int retries;
     private int retrySleep = 0;
@@ -357,6 +358,10 @@ public class Http {
     }
 
     public static URL followRedirectsWithRetry(URL originalUrl, int maxRetries, int baseDelaySeconds, String userAgent) throws IOException {
+        return followRedirectsWithRetry(originalUrl, maxRetries, baseDelaySeconds, userAgent, DEFAULT_ACCEPT_HEADER);
+    }
+
+    public static URL followRedirectsWithRetry(URL originalUrl, int maxRetries, int baseDelaySeconds, String userAgent, String acceptHeader) throws IOException {
         int retries = 0;
         int maxDelaySeconds = 600;
         Random random = new Random();
@@ -368,7 +373,9 @@ public class Http {
                 connection = (HttpURLConnection) currentUrl.openConnection();
                 connection.setInstanceFollowRedirects(false);
                 connection.setRequestProperty("User-Agent", userAgent);
-                connection.setRequestProperty("Accept", "application/json");
+                if (acceptHeader != null) {
+                    connection.setRequestProperty("Accept", acceptHeader);
+                }
                 connection.setConnectTimeout(10000);
                 connection.setReadTimeout(10000);
 

--- a/src/test/java/com/rarchives/ripme/tst/utils/HttpTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/utils/HttpTest.java
@@ -1,0 +1,57 @@
+package com.rarchives.ripme.tst.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.net.InetSocketAddress;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Executors;
+
+import org.junit.jupiter.api.Test;
+
+import com.rarchives.ripme.utils.Http;
+import com.sun.net.httpserver.HttpServer;
+
+public class HttpTest {
+
+    @Test
+    public void testDefaultAcceptHeader() throws Exception {
+        List<String> accepts = new ArrayList<>();
+        HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext("/", exchange -> {
+            accepts.add(exchange.getRequestHeaders().getFirst("Accept"));
+            exchange.sendResponseHeaders(200, -1);
+            exchange.close();
+        });
+        server.setExecutor(Executors.newSingleThreadExecutor());
+        server.start();
+        try {
+            URL url = new URL("http://localhost:" + server.getAddress().getPort() + "/");
+            Http.followRedirectsWithRetry(url, 0, 1, "test-agent");
+        } finally {
+            server.stop(0);
+        }
+        assertEquals("*/*", accepts.get(0));
+    }
+
+    @Test
+    public void testCustomAcceptHeader() throws Exception {
+        List<String> accepts = new ArrayList<>();
+        HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext("/", exchange -> {
+            accepts.add(exchange.getRequestHeaders().getFirst("Accept"));
+            exchange.sendResponseHeaders(200, -1);
+            exchange.close();
+        });
+        server.setExecutor(Executors.newSingleThreadExecutor());
+        server.start();
+        try {
+            URL url = new URL("http://localhost:" + server.getAddress().getPort() + "/");
+            Http.followRedirectsWithRetry(url, 0, 1, "test-agent", "application/json");
+        } finally {
+            server.stop(0);
+        }
+        assertEquals("application/json", accepts.get(0));
+    }
+}


### PR DESCRIPTION
## Summary
- Centralize default `*/*` header in `Http` and only attach `Accept` when provided
- Explicitly request JSON from Coomer API to avoid 403 responses

## Testing
- `./gradlew compileJava`
- `./gradlew test --tests "com.rarchives.ripme.tst.utils.HttpTest" -i` *(fails: Could not resolve org.junit:junit-bom:5.10.0, HTTP 403)*
- `./gradlew test --tests "com.rarchives.ripme.tst.ripper.rippers.CoomerPartyRipperTest" -i` *(fails: Could not resolve org.junit:junit-bom:5.10.0, HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_689fbe816a98832d937c46f621223a64