### PR TITLE
Handle non-JSON redirects in Coomer ripper

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/CoomerPartyRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/CoomerPartyRipper.java
@@ -8,6 +8,9 @@ import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.HashMap;
+import java.util.Map;
+import java.sql.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -31,6 +34,7 @@ import com.rarchives.ripme.ripper.AbstractRipper;
 public class CoomerPartyRipper extends AbstractJSONRipper {
 
     private static final Logger logger = LogManager.getLogger(CoomerPartyRipper.class);
+    private static final String coomerCookies = getCoomerCookiesFromFirefox();
 
     private String IMG_URL_BASE = "https://img.coomer.st";
     private String VID_URL_BASE = "https://c1.coomer.st";
@@ -128,10 +132,13 @@ public class CoomerPartyRipper extends AbstractJSONRipper {
             for (String endpoint : endpointTemplates) {
                 String apiUrl = String.format(endpoint, dom, service, user, offset);
                 try {
-                    String jsonArrayString = Http.url(apiUrl)
-                            .ignoreContentType()
-                            .response()
-                            .body();
+                    Map<String,String> headers = new HashMap<>();
+                    headers.put("Accept", "application/json");
+                    headers.put("Referer", String.format("https://%s/%s/user/%s", dom, service, user));
+                    if (coomerCookies != null) {
+                        headers.put("Cookie", coomerCookies);
+                    }
+                    String jsonArrayString = Http.getWith429Retry(new URL(apiUrl), 5, 5, AbstractRipper.USER_AGENT, headers);
 
                     logger.debug("Raw JSON from API for offset " + offset + ": " + jsonArrayString);
 
@@ -237,7 +244,12 @@ public class CoomerPartyRipper extends AbstractJSONRipper {
     @Override
     protected void downloadURL(URL url, int index) {
         try {
-            URL resolvedUrl = Http.followRedirectsWithRetry(url, 5, 5, AbstractRipper.USER_AGENT);
+            Map<String,String> headers = new HashMap<>();
+            headers.put("Referer", String.format("https://%s/%s/user/%s", domain, service, user));
+            if (coomerCookies != null) {
+                headers.put("Cookie", coomerCookies);
+            }
+            URL resolvedUrl = Http.followRedirectsWithRetry(url, 5, 5, AbstractRipper.USER_AGENT, headers);
             addURLToDownload(resolvedUrl, getPrefix(index));
         } catch (IOException e) {
             logger.error("Failed to resolve or download redirect URL {}: {}", url, e.getMessage());
@@ -339,6 +351,57 @@ public class CoomerPartyRipper extends AbstractJSONRipper {
         } catch (Exception e) {
             logger.error("Unexpected error in pullAttachmentUrls: " + e.getMessage(), e);
         }
+    }
+
+    private static String getCoomerCookiesFromFirefox() {
+        try {
+            String userHome = System.getProperty("user.home");
+            String profilesIniPath = userHome + "/AppData/Roaming/Mozilla/Firefox/profiles.ini";
+            java.nio.file.Path iniPath = java.nio.file.Paths.get(profilesIniPath);
+            if (!java.nio.file.Files.exists(iniPath)) return null;
+            java.util.List<String> lines = java.nio.file.Files.readAllLines(iniPath);
+            java.util.List<String> profilePaths = new java.util.ArrayList<>();
+            for (String line : lines) {
+                if (line.trim().startsWith("Path=")) {
+                    profilePaths.add(line.trim().substring(5));
+                }
+            }
+            logger.info("Found Firefox profiles: {}", profilePaths);
+            for (String profilePath : profilePaths) {
+                String sqlitePath = userHome + "/AppData/Roaming/Mozilla/Firefox/Profiles/" + profilePath + "/cookies.sqlite";
+                sqlitePath = sqlitePath.replace("Profiles/Profiles/", "Profiles/");
+                logger.info("Trying cookies.sqlite at: {}", sqlitePath);
+                try {
+                    Class.forName("org.sqlite.JDBC");
+                    java.nio.file.Path tempCopy = java.nio.file.Files.createTempFile("cookies", ".sqlite");
+                    java.nio.file.Files.copy(java.nio.file.Paths.get(sqlitePath), tempCopy, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+                    try (Connection conn = DriverManager.getConnection("jdbc:sqlite:" + tempCopy.toString())) {
+                        String sql = "SELECT name, value FROM moz_cookies WHERE host LIKE '%coomer%'";
+                        try (Statement stmt = conn.createStatement(); ResultSet rs = stmt.executeQuery(sql)) {
+                            StringBuilder cookieStr = new StringBuilder();
+                            boolean found = false;
+                            while (rs.next()) {
+                                String name = rs.getString("name");
+                                String value = rs.getString("value");
+                                if (cookieStr.length() > 0) cookieStr.append("; ");
+                                cookieStr.append(name).append("=").append(value);
+                                found = true;
+                            }
+                            if (found) {
+                                logger.info("Found Coomer cookies in profile {}: {}", profilePath, cookieStr.length() > 16 ? cookieStr.substring(0,8)+"..."+cookieStr.substring(cookieStr.length()-8) : cookieStr.toString());
+                                return cookieStr.toString();
+                            }
+                        }
+                    }
+                    java.nio.file.Files.deleteIfExists(tempCopy);
+                } catch (Exception e) {
+                    logger.warn("Failed to read cookies from profile {}: {}", profilePath, e.getMessage());
+                }
+            }
+        } catch (Exception e) {
+            logger.warn("Error reading Firefox profiles.ini: {}", e.getMessage());
+        }
+        return null;
     }
 
     private boolean isImage(String path) {

--- a/src/main/java/com/rarchives/ripme/utils/Http.java
+++ b/src/main/java/com/rarchives/ripme/utils/Http.java
@@ -39,6 +39,7 @@ public class Http {
 
     private static final int TIMEOUT = Utils.getConfigInteger("page.timeout", 5 * 1000);
     private static final Logger logger = LogManager.getLogger(Http.class);
+    private static final String DEFAULT_ACCEPT_HEADER = "*/*";
 
     private int retries;
     private int retrySleep = 0;
@@ -203,6 +204,10 @@ public class Http {
     }
 
     public static String getWith429Retry(URL url, int maxRetries, int baseDelaySeconds, String userAgent) throws IOException {
+        return getWith429Retry(url, maxRetries, baseDelaySeconds, userAgent, null);
+    }
+
+    public static String getWith429Retry(URL url, int maxRetries, int baseDelaySeconds, String userAgent, Map<String,String> headers) throws IOException {
     int retries = 0;
     int maxDelaySeconds = 600; // Cap max wait to 10 minutes
     Random random = new Random();
@@ -213,7 +218,18 @@ public class Http {
         try {
             connection = (HttpURLConnection) url.openConnection();
             connection.setRequestProperty("User-Agent", userAgent);
-            connection.setRequestProperty("Accept", "application/json");
+            boolean acceptSet = false;
+            if (headers != null) {
+                for (Map.Entry<String,String> entry : headers.entrySet()) {
+                    connection.setRequestProperty(entry.getKey(), entry.getValue());
+                    if ("accept".equalsIgnoreCase(entry.getKey())) {
+                        acceptSet = true;
+                    }
+                }
+            }
+            if (!acceptSet) {
+                connection.setRequestProperty("Accept", "application/json");
+            }
             connection.setConnectTimeout(10000);
             connection.setReadTimeout(10000);
 
@@ -252,7 +268,7 @@ public class Http {
             }
 
             if (responseCode >= 400) {
-                throw new IOException("HTTP error: " + responseCode);
+                throw new HttpStatusException("HTTP error fetching URL", responseCode, url.toString());
             }
 
             try (InputStream inputStream = connection.getInputStream();
@@ -357,10 +373,25 @@ public class Http {
     }
 
     public static URL followRedirectsWithRetry(URL originalUrl, int maxRetries, int baseDelaySeconds, String userAgent) throws IOException {
+        return followRedirectsWithRetry(originalUrl, maxRetries, baseDelaySeconds, userAgent, (Map<String,String>) null);
+    }
+
+    public static URL followRedirectsWithRetry(URL originalUrl, int maxRetries, int baseDelaySeconds, String userAgent, String acceptHeader) throws IOException {
+        Map<String,String> headers = new HashMap<>();
+        headers.put("Accept", acceptHeader);
+        return followRedirectsWithRetry(originalUrl, maxRetries, baseDelaySeconds, userAgent, headers);
+    }
+
+    public static URL followRedirectsWithRetry(URL originalUrl, int maxRetries, int baseDelaySeconds, String userAgent, Map<String,String> headers) throws IOException {
         int retries = 0;
         int maxDelaySeconds = 600;
         Random random = new Random();
         URL currentUrl = originalUrl;
+
+        String acceptHeader = DEFAULT_ACCEPT_HEADER;
+        if (headers != null && headers.containsKey("Accept")) {
+            acceptHeader = headers.get("Accept");
+        }
 
         while (retries <= maxRetries) {
             HttpURLConnection connection = null;
@@ -368,7 +399,16 @@ public class Http {
                 connection = (HttpURLConnection) currentUrl.openConnection();
                 connection.setInstanceFollowRedirects(false);
                 connection.setRequestProperty("User-Agent", userAgent);
-                connection.setRequestProperty("Accept", "application/json");
+                if (acceptHeader != null) {
+                    connection.setRequestProperty("Accept", acceptHeader);
+                }
+                if (headers != null) {
+                    for (Map.Entry<String,String> entry : headers.entrySet()) {
+                        if (!"accept".equalsIgnoreCase(entry.getKey())) {
+                            connection.setRequestProperty(entry.getKey(), entry.getValue());
+                        }
+                    }
+                }
                 connection.setConnectTimeout(10000);
                 connection.setReadTimeout(10000);
 

--- a/src/test/java/com/rarchives/ripme/tst/utils/HttpTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/utils/HttpTest.java
@@ -1,0 +1,127 @@
+package com.rarchives.ripme.tst.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.net.InetSocketAddress;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import com.rarchives.ripme.utils.Http;
+import com.sun.net.httpserver.HttpServer;
+
+public class HttpTest {
+
+    @Test
+    public void testDefaultAcceptHeader() throws Exception {
+        List<String> accepts = new ArrayList<>();
+        HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext("/", exchange -> {
+            accepts.add(exchange.getRequestHeaders().getFirst("Accept"));
+            exchange.sendResponseHeaders(200, -1);
+            exchange.close();
+        });
+        server.setExecutor(Executors.newSingleThreadExecutor());
+        server.start();
+        try {
+            URL url = new URL("http://localhost:" + server.getAddress().getPort() + "/");
+            Http.followRedirectsWithRetry(url, 0, 1, "test-agent");
+        } finally {
+            server.stop(0);
+        }
+        assertEquals("*/*", accepts.get(0));
+    }
+
+    @Test
+    public void testCustomAcceptHeader() throws Exception {
+        List<String> accepts = new ArrayList<>();
+        HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext("/", exchange -> {
+            accepts.add(exchange.getRequestHeaders().getFirst("Accept"));
+            exchange.sendResponseHeaders(200, -1);
+            exchange.close();
+        });
+        server.setExecutor(Executors.newSingleThreadExecutor());
+        server.start();
+        try {
+            URL url = new URL("http://localhost:" + server.getAddress().getPort() + "/");
+            Http.followRedirectsWithRetry(url, 0, 1, "test-agent", "application/json");
+        } finally {
+            server.stop(0);
+        }
+        assertEquals("application/json", accepts.get(0));
+    }
+
+    @Test
+    public void testFollowRedirectsWithRetryCustomHeaders() throws Exception {
+        List<String> referers = new ArrayList<>();
+        HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext("/", exchange -> {
+            referers.add(exchange.getRequestHeaders().getFirst("Referer"));
+            exchange.sendResponseHeaders(200, -1);
+            exchange.close();
+        });
+        server.setExecutor(Executors.newSingleThreadExecutor());
+        server.start();
+        try {
+            URL url = new URL("http://localhost:" + server.getAddress().getPort() + "/");
+            Map<String,String> headers = new HashMap<>();
+            headers.put("Referer", "https://example.com/page");
+            Http.followRedirectsWithRetry(url, 0, 1, "test-agent", headers);
+        } finally {
+            server.stop(0);
+        }
+        assertEquals("https://example.com/page", referers.get(0));
+    }
+
+    @Test
+    public void testGetWith429RetryDefaultHeaders() throws Exception {
+        List<String> accepts = new ArrayList<>();
+        HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext("/", exchange -> {
+            accepts.add(exchange.getRequestHeaders().getFirst("Accept"));
+            exchange.sendResponseHeaders(200, 0);
+            exchange.getResponseBody().close();
+        });
+        server.setExecutor(Executors.newSingleThreadExecutor());
+        server.start();
+        try {
+            URL url = new URL("http://localhost:" + server.getAddress().getPort() + "/");
+            Http.getWith429Retry(url, 0, 1, "test-agent");
+        } finally {
+            server.stop(0);
+        }
+        assertEquals("application/json", accepts.get(0));
+    }
+
+    @Test
+    public void testGetWith429RetryCustomHeaders() throws Exception {
+        List<String> accepts = new ArrayList<>();
+        List<String> cookies = new ArrayList<>();
+        HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext("/", exchange -> {
+            accepts.add(exchange.getRequestHeaders().getFirst("Accept"));
+            cookies.add(exchange.getRequestHeaders().getFirst("Cookie"));
+            exchange.sendResponseHeaders(200, 0);
+            exchange.getResponseBody().close();
+        });
+        server.setExecutor(Executors.newSingleThreadExecutor());
+        server.start();
+        try {
+            URL url = new URL("http://localhost:" + server.getAddress().getPort() + "/");
+            Map<String,String> headers = new HashMap<>();
+            headers.put("Accept", "*/*");
+            headers.put("Cookie", "foo=bar");
+            Http.getWith429Retry(url, 0, 1, "test-agent", headers);
+        } finally {
+            server.stop(0);
+        }
+        assertEquals("*/*", accepts.get(0));
+        assertEquals("foo=bar", cookies.get(0));
+    }
+}


### PR DESCRIPTION
## Summary
- Load Coomer cookies from Firefox profiles and attach them to API requests
- Add optional header support to `Http.getWith429Retry` and reuse it for Coomer with 429 backoff
- Allow custom headers in `Http.followRedirectsWithRetry` and default `Accept` to `*/*`
- Send `Referer` and cookies for Coomer API and media downloads to avoid 403 errors
- Test custom header handling for redirect helper

## Testing
- `./gradlew compileJava`
- `./gradlew test --tests "com.rarchives.ripme.tst.utils.HttpTest" -i` *(fails: Could not resolve org.junit:junit-bom:5.10.0, HTTP 403)*
- `./gradlew test --tests "com.rarchives.ripme.tst.ripper.rippers.CoomerPartyRipperTest" -i` *(fails: Could not resolve org.junit:junit-bom:5.10.0, HTTP 403)*


------
https://chatgpt.com/codex/tasks/task_e_689fbe816a98832d937c46f621223a64