### PR TITLE
feat: add tab for additional settings

### DIFF
--- a/src/main/java/com/rarchives/ripme/utils/Utils.java
+++ b/src/main/java/com/rarchives/ripme/utils/Utils.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Enumeration;
+import java.util.Iterator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -161,6 +162,14 @@ public class Utils {
             }
         }
         return result;
+    }
+
+    public static List<String> getConfigKeys() {
+        List<String> keys = new ArrayList<>();
+        for (Iterator<String> it = config.getKeys(); it.hasNext();) {
+            keys.add(it.next());
+        }
+        return keys;
     }
 
     public static void setConfigBoolean(String key, boolean value) {


### PR DESCRIPTION
## Summary
- add `getConfigKeys` helper to expose all configuration entries
- introduce "Other Settings" tab to edit properties without dedicated UI
- wire up dynamic fields to allow editing and saving additional settings

## Testing
- `./gradlew test` *(fails: Could not resolve org.junit:junit-bom:5.10.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a0540287c4832d908be0b025ca9c20