### PR TITLE
Handle BOM prefix in CoomerParty JSON

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/CoomerPartyRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/CoomerPartyRipper.java
@@ -144,6 +144,9 @@ public class CoomerPartyRipper extends AbstractJSONRipper {
 
                 JSONArray jsonArray;
                 String trimmed = jsonArrayString.trim();
+                if (!trimmed.isEmpty() && trimmed.charAt(0) == '\uFEFF') {
+                    trimmed = trimmed.substring(1);
+                }
                 if (trimmed.startsWith("[")) {
                     jsonArray = new JSONArray(trimmed);
                 } else {


### PR DESCRIPTION
## Summary
- strip leading BOM characters from CoomerParty API responses before JSON parsing

## Testing
- `./gradlew test` *(fails: Could not resolve all files for configuration ':testCompileClasspath'. Received status code 403 from server)*

------
https://chatgpt.com/codex/tasks/task_e_68a1cac50950832d82f190c3daba43d9