### PR TITLE
Handle BOM prefix in CoomerParty JSON

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/CoomerPartyRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/CoomerPartyRipper.java
@@ -35,8 +35,8 @@ public class CoomerPartyRipper extends AbstractJSONRipper {
 
     private static final Logger logger = LogManager.getLogger(CoomerPartyRipper.class);
     private static final String coomerCookies = getCoomerCookiesFromFirefox();
-    private static final String COOMER_USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
-            + "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36";
+    private static final String COOMER_USER_AGENT =
+            "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)";
 
     private String IMG_URL_BASE = "https://img.coomer.st";
     private String VID_URL_BASE = "https://c1.coomer.st";
@@ -134,7 +134,7 @@ public class CoomerPartyRipper extends AbstractJSONRipper {
             try {
                 Map<String, String> headers = new HashMap<>();
                 headers.put("Accept", "text/css");
-                headers.put("Referer", String.format("https://%s/%s/user/%s", dom, service, user));
+                headers.put("Referer", String.format("https://%s/", dom));
                 if (coomerCookies != null) {
                     headers.put("Cookie", coomerCookies);
                 }
@@ -144,6 +144,9 @@ public class CoomerPartyRipper extends AbstractJSONRipper {
 
                 JSONArray jsonArray;
                 String trimmed = jsonArrayString.trim();
+                if (!trimmed.isEmpty() && trimmed.charAt(0) == '\uFEFF') {
+                    trimmed = trimmed.substring(1);
+                }
                 if (trimmed.startsWith("[")) {
                     jsonArray = new JSONArray(trimmed);
                 } else {
@@ -266,7 +269,8 @@ public class CoomerPartyRipper extends AbstractJSONRipper {
     protected void downloadURL(URL url, int index) {
         try {
             Map<String,String> headers = new HashMap<>();
-            headers.put("Referer", String.format("https://%s/%s/user/%s", domain, service, user));
+            headers.put("Accept", "text/css");
+            headers.put("Referer", String.format("https://%s/", domain));
             if (coomerCookies != null) {
                 headers.put("Cookie", coomerCookies);
             }


### PR DESCRIPTION
## Summary
- strip leading BOM characters from CoomerParty API responses before JSON parsing
- use Googlebot user agent and root Referer/Accept headers for API and media requests

## Testing
- `./gradlew test` *(fails: Could not resolve all files for configuration ':testCompileClasspath'. Received status code 403 from server)*

------
https://chatgpt.com/codex/tasks/task_e_68a1cac50950832d82f190c3daba43d9