### PR TITLE
Increase Reddit 429 backoff delay

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/RedditRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/RedditRipper.java
@@ -121,6 +121,7 @@ public class RedditRipper extends AlbumRipper {
     private static final String REDDIT_USER_AGENT = "RipMe:github.com/laziassdev/ripme:" + UpdateUtils.getThisJarVersion() + " (by /u/metaprime and /u/ineedmorealts)";
 
     private static final int SLEEP_TIME = 2000;
+    private static final int RETRY_DELAY_SECONDS = 20;
 
     private long lastRequestTime = 0;
     private int downloadCounter = 0;
@@ -295,7 +296,7 @@ public class RedditRipper extends AlbumRipper {
             logger.warn("No Reddit cookies found; requests will not be authenticated.");
         }
 
-        String jsonString = Http.getWith429Retry(url, 5, 2, REDDIT_USER_AGENT, headers);
+        String jsonString = Http.getWith429Retry(url, 5, RETRY_DELAY_SECONDS, REDDIT_USER_AGENT, headers);
 
         Object jsonObj = new JSONTokener(jsonString).nextValue();
         JSONArray jsonArray = new JSONArray();


### PR DESCRIPTION
## Summary
- slow Reddit request retries by using a 20s base delay so backoff reaches several minutes by the fifth attempt

## Testing
- `./gradlew test` *(fails: 49 failed, 45 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68a49abe3590832dbed88769312de533