### PR TITLE
Ensure stop button stays enabled on errors

### DIFF
--- a/src/main/java/com/rarchives/ripme/ui/MainWindow.java
+++ b/src/main/java/com/rarchives/ripme/ui/MainWindow.java
@@ -1633,7 +1633,6 @@ public final class MainWindow implements Runnable, RipStatusHandler {
             if (LOGGER.isEnabled(Level.ERROR)) {
                 appendLog((String) msg.getObject(), Color.RED);
             }
-            stopButton.setEnabled(false);
             statusProgress.setValue(0);
             statusProgress.setVisible(false);
             openButton.setVisible(false);
@@ -1741,7 +1740,6 @@ public final class MainWindow implements Runnable, RipStatusHandler {
             if (LOGGER.isEnabled(Level.ERROR)) {
                 appendLog((String) msg.getObject(), Color.RED);
             }
-            stopButton.setEnabled(false);
             statusProgress.setValue(0);
             statusProgress.setVisible(false);
             openButton.setVisible(false);


### PR DESCRIPTION
## Summary
- Avoid disabling the Stop button when a rip errors out
- Keep Stop button available when no album/user is found

## Testing
- `./gradlew test` *(fails: There were failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a49d17f13c832d8b2a6b52d1e046b5