### PR TITLE
Fix history removal index errors when table is sorted

### DIFF
--- a/src/main/java/com/rarchives/ripme/ui/MainWindow.java
+++ b/src/main/java/com/rarchives/ripme/ui/MainWindow.java
@@ -1390,9 +1390,23 @@ public final class MainWindow implements Runnable, RipStatusHandler {
 
         historyButtonRemove.addActionListener(event -> {
             int[] indices = historyTable.getSelectedRows();
-            for (int i = indices.length - 1; i >= 0; i--) {
-                int modelIndex = historyTable.convertRowIndexToModel(indices[i]);
-                HISTORY.remove(modelIndex);
+            if (indices.length == 0) {
+                return;
+            }
+
+            List<Integer> modelIndices = new ArrayList<>(indices.length);
+            for (int index : indices) {
+                if (index < historyTable.getRowCount()) {
+                    modelIndices.add(historyTable.convertRowIndexToModel(index));
+                }
+            }
+
+            modelIndices.sort(Collections.reverseOrder());
+
+            for (int modelIndex : modelIndices) {
+                if (modelIndex < HISTORY.toList().size()) {
+                    HISTORY.remove(modelIndex);
+                }
             }
             try {
                 historyTableModel.fireTableDataChanged();


### PR DESCRIPTION
### Motivation
- Deleting selected rows from the history table while a `RowSorter` is active caused stale view-to-model index conversions and `IndexOutOfBoundsException` during rendering.

### Description
- Return early when no rows are selected and convert selected view indices to model indices once up front using `historyTable.convertRowIndexToModel`.
- Filter out out-of-range view indices, sort model indices in descending order, and check bounds before calling `HISTORY.remove(...)` to avoid invalid removals.
- Preserve existing refresh and persistence behavior by calling `historyTableModel.fireTableDataChanged()` and `saveHistory()` after removals.

### Testing
- Ran the automated test suite with `./gradlew test`, which completed successfully (BUILD SUCCESSFUL).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da53f40958832db89b27dbd0d3bf8b)