### PR TITLE
Improve history UX: datetime display, recency ordering, and wildcard search

### DIFF
--- a/src/main/java/com/rarchives/ripme/ui/History.java
+++ b/src/main/java/com/rarchives/ripme/ui/History.java
@@ -7,6 +7,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 
@@ -68,8 +69,18 @@ public class History {
         }
     }
     private String dateToHumanReadable(Date date) {
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy/MM/dd");
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss");
         return sdf.format(date);
+    }
+
+    public void moveToBottom(HistoryEntry entry) {
+        if (list.remove(entry)) {
+            list.add(entry);
+        }
+    }
+
+    public void sortByModifiedDateAscending() {
+        list.sort(Comparator.comparing(entry -> entry.modifiedDate));
     }
 
     public boolean containsURL(String url) {

--- a/src/main/java/com/rarchives/ripme/ui/MainWindow.java
+++ b/src/main/java/com/rarchives/ripme/ui/MainWindow.java
@@ -42,6 +42,7 @@ import javax.swing.event.DocumentListener;
 import javax.swing.event.ListDataEvent;
 import javax.swing.event.ListDataListener;
 import javax.swing.table.AbstractTableModel;
+import javax.swing.table.TableRowSorter;
 import javax.swing.text.*;
 
 import org.apache.logging.log4j.Level;
@@ -106,7 +107,9 @@ public final class MainWindow implements Runnable, RipStatusHandler {
     private static JPanel historyPanel;
     private static JTable historyTable;
     private static AbstractTableModel historyTableModel;
+    private static TableRowSorter<AbstractTableModel> historyTableSorter;
     private static JButton historyButtonRemove, historyButtonClear, historyButtonRerip;
+    private static JTextField historySearchField;
 
     // Queue
     public static JButton optionQueue;
@@ -191,6 +194,50 @@ public final class MainWindow implements Runnable, RipStatusHandler {
 
     private void updateQueue() {
         updateQueue(null);
+    }
+
+    private static void applyHistoryFilter() {
+        if (historyTableSorter == null || historySearchField == null) {
+            return;
+        }
+        String query = historySearchField.getText();
+        if (query == null || query.trim().isEmpty()) {
+            historyTableSorter.setRowFilter(null);
+            return;
+        }
+        historyTableSorter.setRowFilter(RowFilter.regexFilter("(?i)" + wildcardToRegex(query.trim())));
+    }
+
+    private static String wildcardToRegex(String wildcard) {
+        StringBuilder regex = new StringBuilder();
+        for (char c : wildcard.toCharArray()) {
+            switch (c) {
+            case '*':
+                regex.append(".*");
+                break;
+            case '?':
+                regex.append('.');
+                break;
+            case '\\':
+            case '.':
+            case '^':
+            case '$':
+            case '|':
+            case '(':
+            case ')':
+            case '[':
+            case ']':
+            case '{':
+            case '}':
+            case '+':
+                regex.append('\\').append(c);
+                break;
+            default:
+                regex.append(c);
+                break;
+            }
+        }
+        return regex.toString();
     }
 
     private void refreshActivePanel() {
@@ -771,7 +818,8 @@ public final class MainWindow implements Runnable, RipStatusHandler {
 
         historyTable = new JTable(historyTableModel);
         historyTable.addMouseListener(new HistoryMenuMouseListener());
-        historyTable.setAutoCreateRowSorter(true);
+        historyTableSorter = new TableRowSorter<>(historyTableModel);
+        historyTable.setRowSorter(historyTableSorter);
 
         for (int i = 0; i < historyTable.getColumnModel().getColumnCount(); i++) {
             int width = 130; // Default
@@ -790,12 +838,44 @@ public final class MainWindow implements Runnable, RipStatusHandler {
         }
 
         JScrollPane historyTableScrollPane = new JScrollPane(historyTable);
+        historySearchField = new JTextField(30);
+        historySearchField.getDocument().addDocumentListener(new DocumentListener() {
+            @Override
+            public void insertUpdate(DocumentEvent e) {
+                applyHistoryFilter();
+            }
+
+            @Override
+            public void removeUpdate(DocumentEvent e) {
+                applyHistoryFilter();
+            }
+
+            @Override
+            public void changedUpdate(DocumentEvent e) {
+                applyHistoryFilter();
+            }
+        });
+        JPanel historySearchPanel = new JPanel(new GridBagLayout());
+        GridBagConstraints historySearchGbc = new GridBagConstraints();
+        historySearchGbc.gridx = 0;
+        historySearchGbc.gridy = 0;
+        historySearchGbc.anchor = GridBagConstraints.WEST;
+        historySearchPanel.add(new JLabel("Search (*, ?)"), historySearchGbc);
+        historySearchGbc.gridx = 1;
+        historySearchGbc.weightx = 1;
+        historySearchGbc.fill = GridBagConstraints.HORIZONTAL;
+        historySearchGbc.insets = new Insets(0, 8, 0, 0);
+        historySearchPanel.add(historySearchField, historySearchGbc);
         historyButtonRemove = new JButton(Utils.getLocalizedString("remove"));
         historyButtonClear = new JButton(Utils.getLocalizedString("clear"));
         historyButtonRerip = new JButton(Utils.getLocalizedString("re-rip.checked"));
         gbc.gridx = 0;
         // History List Panel
         JPanel historyTablePanel = new JPanel(new GridBagLayout());
+        gbc.weighty = 0;
+        gbc.fill = GridBagConstraints.HORIZONTAL;
+        historyTablePanel.add(historySearchPanel, gbc);
+        gbc.gridy = 1;
         gbc.fill = GridBagConstraints.BOTH;
         gbc.weighty = 1;
         historyTablePanel.add(historyTableScrollPane, gbc);
@@ -1797,6 +1877,7 @@ public final class MainWindow implements Runnable, RipStatusHandler {
             try {
                 LOGGER.info(Utils.getLocalizedString("loading.history.from") + " " + historyFile.getCanonicalPath());
                 HISTORY.fromFile(historyFile.getCanonicalPath());
+                HISTORY.sortByModifiedDateAscending();
             } catch (IOException e) {
                 LOGGER.error("Failed to load history from file " + historyFile, e);
                 JOptionPane.showMessageDialog(null,
@@ -2205,6 +2286,7 @@ public final class MainWindow implements Runnable, RipStatusHandler {
                 entry = HISTORY.getEntryByURL(url);
                 entry.count += rsc.count;
                 entry.modifiedDate = new Date();
+                HISTORY.moveToBottom(entry);
                 if (entry.dir == null || entry.dir.isEmpty()) {
                     entry.dir = rsc.getDir();
                 }
@@ -2221,6 +2303,7 @@ public final class MainWindow implements Runnable, RipStatusHandler {
                 HISTORY.add(entry);
             }
             historyTableModel.fireTableDataChanged();
+            applyHistoryFilter();
             if (configPlaySound.isSelected()) {
                 Utils.playSound("camera.wav");
             }


### PR DESCRIPTION
### Motivation
- Make the History view more useful by showing full timestamps (date + time) so users can see when rips actually occurred.
- Ensure the most recently modified history item appears at the bottom of the list (so the bottom represents the latest change).
- Add a quick in-UI search with simple wildcard support so users can filter history entries interactively.

### Description
- Show full timestamp in History by changing the human-readable formatter to `yyyy/MM/dd HH:mm:ss` in `History.dateToHumanReadable(Date)` (`History.java`).
- Add `moveToBottom(HistoryEntry)` and `sortByModifiedDateAscending()` helpers to `History` and call `sortByModifiedDateAscending()` when loading `history.json` so older->newer order is preserved; call `moveToBottom()` when an existing entry is updated on rip completion so the most-recently-modified entry moves to the bottom (`History.java`, `MainWindow.java`).
- Add a search box above the History table and a `TableRowSorter`-based filter that supports case-insensitive wildcard patterns (`*` -> any sequence, `?` -> single character) via `wildcardToRegex()` and `applyHistoryFilter()`; wire the search field to live updates on document change (`MainWindow.java`).
- Re-apply the history filter after table refreshes so results stay consistent when entries are added/updated (`MainWindow.java`).

### Testing
- `./gradlew compileJava` completed successfully.
- `./gradlew test --tests com.rarchives.ripme.ui.UIContextMenuTests` was attempted but Gradle reported no tests matched the provided filter in this environment (no tests ran for that target).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da576ea14c832dbe4b46a42657833a)