### PR TITLE
Add latest-download tracking to History tab

### DIFF
--- a/src/main/java/com/rarchives/ripme/ui/History.java
+++ b/src/main/java/com/rarchives/ripme/ui/History.java
@@ -22,6 +22,7 @@ public class History {
         "URL",
         "created",
         "modified",
+        "latest",
         "#",
         ""
     };
@@ -61,8 +62,10 @@ public class History {
         case 2:
             return dateToHumanReadable(entry.modifiedDate);
         case 3:
-            return entry.count;
+            return entry.latestCount;
         case 4:
+            return entry.count;
+        case 5:
             return entry.selected;
         default:
             return null;

--- a/src/main/java/com/rarchives/ripme/ui/HistoryEntry.java
+++ b/src/main/java/com/rarchives/ripme/ui/HistoryEntry.java
@@ -9,7 +9,8 @@ public class HistoryEntry {
     public String  url          = "",
                    title        = "",
                    dir          = "";
-    public int     count        = 0;
+    public int     count        = 0,
+                   latestCount  = 0;
     public Date    startDate    = new Date(),
                    modifiedDate = new Date();
     public boolean selected     = false;
@@ -27,6 +28,9 @@ public class HistoryEntry {
         if (json.has("count")) {
             this.count    = json.getInt("count");
         }
+        if (json.has("latestCount")) {
+            this.latestCount = json.getInt("latestCount");
+        }
         if (json.has("dir")) {
             this.dir      = json.getString("dir");
         }
@@ -43,6 +47,7 @@ public class HistoryEntry {
         json.put("modifiedDate", this.modifiedDate.getTime());
         json.put("title",        this.title);
         json.put("count",        this.count);
+        json.put("latestCount",  this.latestCount);
         json.put("selected",     this.selected);
         return json;
     }

--- a/src/main/java/com/rarchives/ripme/ui/MainWindow.java
+++ b/src/main/java/com/rarchives/ripme/ui/MainWindow.java
@@ -804,12 +804,12 @@ public final class MainWindow implements Runnable, RipStatusHandler {
 
             @Override
             public boolean isCellEditable(int row, int col) {
-                return (col == 0 || col == 4);
+                return (col == 0 || col == 5);
             }
 
             @Override
             public void setValueAt(Object value, int row, int col) {
-                if (col == 4) {
+                if (col == 5) {
                     HISTORY.get(row).selected = (Boolean) value;
                     historyTableModel.fireTableDataChanged();
                 }
@@ -831,6 +831,9 @@ public final class MainWindow implements Runnable, RipStatusHandler {
                 width = 40;
                 break;
             case 4:
+                width = 40;
+                break;
+            case 5:
                 width = 15;
                 break;
             }
@@ -2029,6 +2032,13 @@ public final class MainWindow implements Runnable, RipStatusHandler {
                     HISTORY.add(entry);
                     historyTableModel.fireTableDataChanged();
                     saveHistory();
+                } else {
+                    HistoryEntry entry = HISTORY.getEntryByURL(ripUrl);
+                    entry.latestCount = 0;
+                    if (entry.dir == null || entry.dir.isEmpty()) {
+                        entry.dir = ripper.getWorkingDir().getAbsolutePath();
+                    }
+                    historyTableModel.fireTableDataChanged();
                 }
 
                 Thread t = new Thread(ripper);
@@ -2284,6 +2294,7 @@ public final class MainWindow implements Runnable, RipStatusHandler {
             HistoryEntry entry;
             if (HISTORY.containsURL(url)) {
                 entry = HISTORY.getEntryByURL(url);
+                entry.latestCount = rsc.count;
                 entry.count += rsc.count;
                 entry.modifiedDate = new Date();
                 HISTORY.moveToBottom(entry);
@@ -2294,6 +2305,7 @@ public final class MainWindow implements Runnable, RipStatusHandler {
                 entry = new HistoryEntry();
                 entry.url = url;
                 entry.dir = rsc.getDir();
+                entry.latestCount = rsc.count;
                 entry.count = rsc.count;
                 try {
                     entry.title = evt.ripper.getAlbumTitle(evt.ripper.getURL());


### PR DESCRIPTION
### Motivation
- Provide a per-entry "latest" column in the History table that shows the most recent rip count for an entry while keeping the existing cumulative `#` total, and reset `latest` to 0 when a new rip for an existing entry starts.

### Description
- Add `latestCount` to `HistoryEntry` and persist it in `toJSON`/`fromJSON` so history files continue to load when the field is absent.
- Add a new `latest` column in `History` and return `latestCount` for that column while keeping the cumulative `count` column, shifting the checkbox column index accordingly.
- Update `MainWindow` to reset `entry.latestCount = 0` when starting a rip for an existing history entry, set `entry.latestCount = rsc.count` on `RIP_COMPLETE`, and continue incrementing `entry.count` for the total.
- Adjust the history table model to account for the new column (editable column index and preferred widths).

### Testing
- `./gradlew testClasses` executed successfully (project compiles and test classes are up-to-date).
- `./gradlew test --tests com.rarchives.ripme.ui.RipButtonHandlerTest --tests com.rarchives.ripme.ui.UIContextMenuTests` was attempted but Gradle reported no tests matched the given include filters in this project setup.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da6ee821ac832d97e07706f99a4b7d)