### PR TITLE
Fix right-click context menu triggers for history, queue, and text fields

### DIFF
--- a/src/main/java/com/rarchives/ripme/ui/ContextMenuMouseListener.java
+++ b/src/main/java/com/rarchives/ripme/ui/ContextMenuMouseListener.java
@@ -7,7 +7,9 @@ import java.awt.datatransfer.Clipboard;
 import java.awt.datatransfer.DataFlavor;
 import java.awt.datatransfer.Transferable;
 import java.awt.datatransfer.UnsupportedFlavorException;
-import java.awt.event.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
 import java.io.IOException;
 
 import javax.swing.*;
@@ -159,17 +161,6 @@ public class ContextMenuMouseListener extends MouseAdapter {
 
     private void showPopup(MouseEvent e) {
         if (e.isPopupTrigger()) {
-            if(this.popup == null) {
-                popup = new JPopupMenu();
-                generate_popup();
-            }
-            popup.show(e.getComponent(), e.getX(), e.getY());
-        }
-    }
-
-    @Override
-    public void mouseClicked(MouseEvent e) {
-        if (e.getModifiersEx() == InputEvent.BUTTON3_DOWN_MASK) {
             if (!(e.getSource() instanceof JTextComponent)) {
                 return;
             }
@@ -182,7 +173,8 @@ public class ContextMenuMouseListener extends MouseAdapter {
             boolean nonempty = !(textComponent.getText() == null || textComponent.getText().equals(""));
             boolean marked = textComponent.getSelectedText() != null;
 
-            boolean pasteAvailable = Toolkit.getDefaultToolkit().getSystemClipboard().getContents(null).isDataFlavorSupported(DataFlavor.stringFlavor);
+            boolean pasteAvailable = Toolkit.getDefaultToolkit().getSystemClipboard().getContents(null)
+                    .isDataFlavorSupported(DataFlavor.stringFlavor);
 
             undoAction.setEnabled(enabled && editable && (lastActionSelected == Actions.CUT || lastActionSelected == Actions.PASTE));
             cutAction.setEnabled(enabled && editable && marked);
@@ -190,6 +182,10 @@ public class ContextMenuMouseListener extends MouseAdapter {
             pasteAction.setEnabled(enabled && editable && pasteAvailable);
             selectAllAction.setEnabled(enabled && nonempty);
 
+            if(this.popup == null) {
+                popup = new JPopupMenu();
+                generate_popup();
+            }
             int nx = e.getX();
 
             if (nx > 500) {

--- a/src/main/java/com/rarchives/ripme/ui/HistoryMenuMouseListener.java
+++ b/src/main/java/com/rarchives/ripme/ui/HistoryMenuMouseListener.java
@@ -1,7 +1,6 @@
 package com.rarchives.ripme.ui;
 
 import java.awt.event.ActionEvent;
-import java.awt.event.InputEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 
@@ -72,7 +71,7 @@ class HistoryMenuMouseListener extends MouseAdapter {
     }
 
     private void checkPopupTrigger(MouseEvent e) {
-        if (e.getModifiersEx() == InputEvent.BUTTON3_DOWN_MASK) {
+        if (e.isPopupTrigger()) {
             if (!(e.getSource() instanceof JTable)) {
                 return;
             }

--- a/src/main/java/com/rarchives/ripme/ui/QueueMenuMouseListener.java
+++ b/src/main/java/com/rarchives/ripme/ui/QueueMenuMouseListener.java
@@ -1,7 +1,6 @@
 package com.rarchives.ripme.ui;
 
 import java.awt.event.ActionEvent;
-import java.awt.event.InputEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.util.ArrayList;
@@ -143,7 +142,7 @@ class QueueMenuMouseListener extends MouseAdapter {
 
     @SuppressWarnings("unchecked")
     private void checkPopupTrigger(MouseEvent e) {
-        if (e.getModifiersEx() == InputEvent.BUTTON3_DOWN_MASK) {
+        if (e.isPopupTrigger()) {
             if (!(e.getSource() instanceof JList)) {
                 return;
             }


### PR DESCRIPTION
### Motivation
- Right-click/context-menu actions (e.g. history "Check All" / "Check None") were unreliable because event handling relied on an exact right-button modifier comparison which can be brittle across platforms and JVM event sequences.
- Use the platform-correct popup detection to restore consistent behavior for list/table and text-field context menus.

### Description
- Replaced modifier-based checks in `HistoryMenuMouseListener` and `QueueMenuMouseListener` with `MouseEvent#isPopupTrigger()` so popups appear reliably on platform-specific popup triggers.
- Consolidated the text-field context-menu logic in `ContextMenuMouseListener` to compute action enabled states and show the popup within the same `isPopupTrigger()` path, removing the previous separate `mouseClicked` path that used modifier checks. 
- Cleaned up unused/wildcard event imports in the three modified listeners.

### Testing
- Ran `./gradlew test --tests '*DownloadLimitTrackerTest'`, which completed successfully. 
- Attempted to run `./gradlew test --tests com.rarchives.ripme.ui.UIContextMenuTests` and `./gradlew test --tests '*UIContextMenuTests'`, but Gradle reported "No tests found" for those filters so the UI-specific filtered tests were not executed. 
- Project compilation completed during the test runs (no compilation errors occurred).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da789c5ccc832d8af24b968337beae)