### PR TITLE
Fix history right-click check/uncheck actions

### DIFF
--- a/src/main/java/com/rarchives/ripme/ui/HistoryMenuMouseListener.java
+++ b/src/main/java/com/rarchives/ripme/ui/HistoryMenuMouseListener.java
@@ -21,7 +21,7 @@ class HistoryMenuMouseListener extends MouseAdapter {
             @Override
             public void actionPerformed(ActionEvent ae) {
                 for (int row = 0; row < tableComponent.getRowCount(); row++) {
-                    tableComponent.setValueAt(true, row, 4);
+                    tableComponent.setValueAt(true, row, 5);
                 }
             }
         };
@@ -31,7 +31,7 @@ class HistoryMenuMouseListener extends MouseAdapter {
             @Override
             public void actionPerformed(ActionEvent ae) {
                 for (int row = 0; row < tableComponent.getRowCount(); row++) {
-                    tableComponent.setValueAt(false, row, 4);
+                    tableComponent.setValueAt(false, row, 5);
                 }
             }
         };
@@ -43,7 +43,7 @@ class HistoryMenuMouseListener extends MouseAdapter {
             @Override
             public void actionPerformed(ActionEvent ae) {
                 for (int row : tableComponent.getSelectedRows()) {
-                    tableComponent.setValueAt(true, row, 4);
+                    tableComponent.setValueAt(true, row, 5);
                 }
             }
         };
@@ -53,7 +53,7 @@ class HistoryMenuMouseListener extends MouseAdapter {
             @Override
             public void actionPerformed(ActionEvent ae) {
                 for (int row : tableComponent.getSelectedRows()) {
-                    tableComponent.setValueAt(false, row, 4);
+                    tableComponent.setValueAt(false, row, 5);
                 }
             }
         };


### PR DESCRIPTION
### Motivation
- The History tab context-menu actions (`Check All`, `Check None`, `Check Selected`, `Uncheck Selected`) were not affecting the checkbox state when invoked from the right-click menu. 
- Root cause: the context menu wrote to column `4` while the history table model stores the selectable checkbox in column `5`, so updates were ignored by the model.

### Description
- Updated `HistoryMenuMouseListener` to write to column index `5` for `Check All`, `Check None`, `Check Selected`, and `Uncheck Selected` so the model persists selection changes. 
- The change is localized to `src/main/java/com/rarchives/ripme/ui/HistoryMenuMouseListener.java` and aligns the menu actions with `MainWindow`'s history table model which uses column `5` for the selectable checkbox.

### Testing
- Ran the test suite with `./gradlew test` and the build completed successfully (`BUILD SUCCESSFUL`).
- No test failures were reported after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db68e36f68832d8604222b1ce70061)