### PR TITLE
Harden Redgifs singleton URL regex against backtracking

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/RedgifsRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/RedgifsRipper.java
@@ -61,7 +61,7 @@ public class RedgifsRipper extends AbstractJSONRipper {
     private static final Pattern NICHES_PATTERN = Pattern
             .compile("^https?://[a-zA-Z0-9.]*redgifs\\.com/niches/([a-zA-Z0-9_.-]+).*$");
     private static final Pattern SINGLETON_PATTERN = Pattern
-            .compile("^https?://[a-zA-Z0-9.]*redgifs\\.com/(?:watch|ifr)/([a-zA-Z0-9_-]+).*$");
+            .compile("^https?://[a-zA-Z0-9.]*redgifs\\.com/(?:watch|ifr)/([a-zA-Z0-9_-]+)(?:[/?#].*)?$");
     private static final Pattern DIRECT_IMAGE_PATTERN = Pattern
             .compile("^https?://i\\.redgifs\\.com/i/([a-zA-Z0-9_-]+)(?:\\.[a-zA-Z0-9]+)?(?:\\?.*)?$");
     private static final Pattern ACCESS_TOKEN_PATTERN = Pattern


### PR DESCRIPTION
### Motivation
- Tighten `SINGLETON_PATTERN` in `RedgifsRipper` to eliminate an ambiguous trailing `.*` that could cause polynomial backtracking on crafted `/ifr/-----...` inputs and mitigate a potential ReDoS risk.

### Description
- Replace the suffix of the regex in `src/main/java/com/rarchives/ripme/ripper/rippers/RedgifsRipper.java` from `([a-zA-Z0-9_-]+).*$` to `([a-zA-Z0-9_-]+)(?:[/?#].*)?$` so the video id capture is followed by an optional delimiter-led tail instead of a greedy wildcard.

### Testing
- Ran `./gradlew test --tests com.rarchives.ripme.tst.ripper.rippers.RedgifsRipperTest.testRedgifsIfrURLIsSanitizedToWatch --tests com.rarchives.ripme.tst.ripper.rippers.RedgifsRipperTest.testRedgifsDirectImageURLIsSanitizedToWatch` and the tests completed successfully (build finished `BUILD SUCCESSFUL`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db6b240a48832dbdc32f9bd7dea608)