### PR TITLE
Improve URL wrapping to prevent window expansion

### DIFF
--- a/src/main/java/com/rarchives/ripme/ui/MainWindow.java
+++ b/src/main/java/com/rarchives/ripme/ui/MainWindow.java
@@ -379,15 +379,27 @@ public final class MainWindow implements Runnable, RipStatusHandler {
     }
 
     private static String addSoftWrapPoints(String text) {
-        StringBuilder wrapped = new StringBuilder(text.length() + (text.length() / 4));
+        final int maxUnbrokenRun = 20;
+        StringBuilder wrapped = new StringBuilder(text.length() + (text.length() / 3));
+        int unbrokenRunLength = 0;
         for (int i = 0; i < text.length(); i++) {
             char c = text.charAt(i);
             wrapped.append(c);
-            if (c == '/' || c == '?' || c == '&' || c == '=' || c == '#' || c == '-' || c == '_' || c == '.') {
+            unbrokenRunLength++;
+            if (isNaturalWrapPoint(c)) {
                 wrapped.append("<wbr>");
+                unbrokenRunLength = 0;
+            } else if (unbrokenRunLength >= maxUnbrokenRun) {
+                wrapped.append("<wbr>");
+                unbrokenRunLength = 0;
             }
         }
         return wrapped.toString();
+    }
+
+    private static boolean isNaturalWrapPoint(char c) {
+        return c == '/' || c == '?' || c == '&' || c == '=' || c == '#' || c == '-' || c == '_' || c == '.'
+                || c == ':' || c == '%' || c == '+' || c == '~';
     }
 
     private void addPausedUrl(String url) {


### PR DESCRIPTION
### Motivation
- Long URLs with few natural separators were causing `JLabel` contents to expand the UI to the full monitor width. 
- The goal is to ensure URL labels wrap more reliably in the active downloads/history UI without changing layout constraints. 

### Description
- Updated `addSoftWrapPoints` in `MainWindow` to insert `<wbr>` not only at natural URL separators but also as a fallback every 20 consecutive non-break characters. 
- Added `isNaturalWrapPoint(char)` to centralize which characters produce explicit soft-wrap opportunities and extended the set to include `: % + ~`. 
- Increased the `StringBuilder` buffer sizing slightly and reset the unbroken-run counter after inserting a soft-wrap to avoid very long token segments stretching the UI. 

### Testing
- Ran `./gradlew test --no-daemon` and the test suite completed successfully (`BUILD SUCCESSFUL`).
- Tests emitted warnings about deprecated `URL(String)` usage, but no test failures occurred.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfd26112cc832db1d482c6c8300719)