### PR TITLE
Set Referer for Redgifs media downloads to reduce 403s

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/RedgifsRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/RedgifsRipper.java
@@ -218,7 +218,9 @@ public class RedgifsRipper extends AbstractJSONRipper {
     public void downloadURL(URL url, int index) {
          // redgifs is easy to trigger rate limit, so be a little cautious
         sleep(3000);
-        addURLToDownload(url, getPrefix(index));
+        // Redgifs media hosts increasingly enforce hotlink checks and can return
+        // 403 when the request does not include a Redgifs referer.
+        addURLToDownload(url, getPrefix(index), "", "https://www.redgifs.com/", null);
     }
 
     @Override


### PR DESCRIPTION
### Motivation
- Redgifs media endpoints are returning non-retriable `403` errors when requests lack a Redgifs referer, indicating stricter hotlink checks by the CDN.  

### Description
- Update `RedgifsRipper#downloadURL` to queue downloads with an explicit `Referer: https://www.redgifs.com/` by calling `addURLToDownload(url, getPrefix(index), "", "https://www.redgifs.com/", null)`.  
- Preserve the existing 3s pacing (`sleep(3000)`) to avoid rate limiting.  
- Add a short comment documenting the hotlink / 403 behavior.

### Testing
- Ran `./gradlew test --tests com.rarchives.ripme.tst.ripper.rippers.RedgifsRipperTest` which completed successfully (BUILD SUCCESSFUL).  
- Project test task completed successfully as part of the run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef2ea53b20832da8a1988275e7bbb5)