### PR TITLE
Merge Coomer/OnlyFans outputs into originating Reddit rip folder

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/RedditRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/RedditRipper.java
@@ -22,7 +22,11 @@ import java.net.URL;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.FileVisitResult;
 import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
@@ -757,10 +761,59 @@ public class RedditRipper extends AlbumRipper {
             ripper.setObserver(getObserver());
             ripper.setup();
             ripper.run();
+            mergeCoomerOutputIntoRedditFolder(ripper, coomerUrl);
         } catch (Exception e) {
             logger.warn("Failed to rip Coomer profile {} from OnlyFans link {}: {}", coomerUrl, originalURL, e.getMessage());
         }
         return true;
+    }
+
+    private void mergeCoomerOutputIntoRedditFolder(AbstractRipper coomerRipper, URL coomerUrl) {
+        if (coomerRipper == null || coomerRipper.getWorkingDir() == null || this.workingDir == null) {
+            return;
+        }
+        Path coomerOutputDir = coomerRipper.getWorkingDir().toPath();
+        Path redditOutputDir = this.workingDir.toPath();
+        if (coomerOutputDir.equals(redditOutputDir)) {
+            return;
+        }
+        boolean overwrite = Utils.getConfigBoolean("file.overwrite", false);
+        try {
+            Files.walkFileTree(coomerOutputDir, new SimpleFileVisitor<Path>() {
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                    Path relativePath = coomerOutputDir.relativize(file);
+                    Path targetPath = redditOutputDir.resolve(relativePath);
+                    if (targetPath.getParent() != null) {
+                        Files.createDirectories(targetPath.getParent());
+                    }
+
+                    if (overwrite) {
+                        Files.move(file, targetPath, StandardCopyOption.REPLACE_EXISTING);
+                    } else if (Files.exists(targetPath)) {
+                        logger.debug("Skipping Coomer file already present in Reddit output: {}", targetPath);
+                        Files.delete(file);
+                    } else {
+                        Files.move(file, targetPath);
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+                    if (exc != null) {
+                        throw exc;
+                    }
+                    if (!dir.equals(redditOutputDir)) {
+                        Files.deleteIfExists(dir);
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+            logger.info("Merged Coomer output {} into Reddit folder {}", coomerUrl, Utils.removeCWD(redditOutputDir));
+        } catch (IOException e) {
+            logger.warn("Unable to merge Coomer output from {} into {}: {}", coomerUrl, redditOutputDir, e.getMessage());
+        }
     }
 
     private void handleGallery(JSONArray data, JSONObject metadata, String id, String title){


### PR DESCRIPTION
### Motivation
- When a Reddit rip spawns a Coomer/OnlyFans rip the downloaded files were left in a separate folder which caused duplicate downstream processing (for example duplicate LoRA generation). 
- The change consolidates files from the spawned ripper back into the originating Reddit working directory to avoid duplicates and simplify downstream workflows.

### Description
- Call `mergeCoomerOutputIntoRedditFolder(...)` right after the spawned ripper completes to consolidate its output into the Reddit ripper's `workingDir`.
- Add `mergeCoomerOutputIntoRedditFolder` which recursively walks the spawned ripper's output tree and moves files into the parent Reddit folder while preserving relative paths and creating necessary parent directories.
- Respect `file.overwrite` configuration by replacing existing files when enabled and deleting source files when skipping duplicates, and remove emptied source directories after the move.
- Add imports for file-tree traversal and copy options and add logging for successful merges and merge failures, with null/equality checks to avoid merging into the same directory.

### Testing
- Ran the Reddit unit tests with `./gradlew test --tests com.rarchives.ripme.ripper.rippers.RedditRipperTest` and the build completed successfully (tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef4360d320832dba0ae1072a0f7a4d)