### PR TITLE
Normalize Instagram queue URLs by stripping tracking parameters

### DIFF
--- a/src/main/java/com/rarchives/ripme/ui/MainWindow.java
+++ b/src/main/java/com/rarchives/ripme/ui/MainWindow.java
@@ -511,7 +511,36 @@ public final class MainWindow implements Runnable, RipStatusHandler {
     }
 
     public static void addUrlToQueue(String url) {
-        queueListModel.addElement(url);
+        queueListModel.addElement(normalizeQueueUrl(url));
+    }
+
+    static String normalizeQueueUrl(String rawUrl) {
+        if (rawUrl == null) {
+            return null;
+        }
+        String trimmed = rawUrl.trim();
+        if (trimmed.isEmpty()) {
+            return trimmed;
+        }
+        try {
+            String candidate = trimmed.startsWith("http://") || trimmed.startsWith("https://")
+                    ? trimmed
+                    : "http://" + trimmed;
+            URL parsed = new URI(candidate).toURL();
+            String host = parsed.getHost().toLowerCase(Locale.ROOT);
+            if (host.equals("instagram.com") || host.equals("www.instagram.com")) {
+                String path = parsed.getPath();
+                while (path.endsWith("/") && path.length() > 1) {
+                    path = path.substring(0, path.length() - 1);
+                }
+                URL sanitized = new URI(parsed.getProtocol(), parsed.getUserInfo(), parsed.getHost(), parsed.getPort(),
+                        path, null, null).toURL();
+                return sanitized.toExternalForm();
+            }
+        } catch (URISyntaxException | MalformedURLException ignored) {
+            // Fall back to original input for any unparsable values.
+        }
+        return trimmed;
     }
 
     public MainWindow() throws IOException {
@@ -2200,7 +2229,7 @@ public final class MainWindow implements Runnable, RipStatusHandler {
         }
 
         public void actionPerformed(ActionEvent event) {
-            String url = ripTextfield.getText();
+            String url = normalizeQueueUrl(ripTextfield.getText());
             boolean url_not_empty = !url.equals("");
             if (!queueListModel.contains(url) && url_not_empty) {
                 // Check if we're ripping a range of urls
@@ -2211,7 +2240,7 @@ public final class MainWindow implements Runnable, RipStatusHandler {
                         int rangeStart = Integer.parseInt(rangeToParse.split("-")[0]);
                         int rangeEnd = Integer.parseInt(rangeToParse.split("-")[1]);
                         for (int i = rangeStart; i < rangeEnd + 1; i++) {
-                            String realURL = url.replaceAll("\\{\\S*\\}", Integer.toString(i));
+                            String realURL = normalizeQueueUrl(url.replaceAll("\\{\\S*\\}", Integer.toString(i)));
                             if (mainWindow.canRip(realURL)) {
                                 queueListModel.addElement(realURL);
                                 ripTextfield.setText("");

--- a/src/test/java/com/rarchives/ripme/ui/MainWindowQueueUrlNormalizationTest.java
+++ b/src/test/java/com/rarchives/ripme/ui/MainWindowQueueUrlNormalizationTest.java
@@ -1,0 +1,37 @@
+package com.rarchives.ripme.ui;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+
+public class MainWindowQueueUrlNormalizationTest {
+
+    @Test
+    public void normalizesInstagramTrackingParameters() {
+        assertEquals(
+                "https://www.instagram.com/beccapoppyhaigh",
+                MainWindow.normalizeQueueUrl("https://www.instagram.com/beccapoppyhaigh/?g=5"));
+        assertEquals(
+                "https://www.instagram.com/lyssaurora",
+                MainWindow.normalizeQueueUrl(
+                        "https://www.instagram.com/lyssaurora/?e=ee8f574d-9a29-4bb3-b0e5-e5a04685a595&g=5"));
+    }
+
+    @Test
+    public void leavesNonInstagramUrlsUntouched() {
+        String reddit = "https://www.reddit.com/search/?q=missy+mae&type=media";
+        assertEquals(reddit, MainWindow.normalizeQueueUrl(reddit));
+    }
+
+    @Test
+    public void addUrlToQueueStoresNormalizedInstagramUrl() throws IOException {
+        MainWindow mainWindow = new MainWindow(true);
+        MainWindow.getQueueListModel().clear();
+
+        MainWindow.addUrlToQueue("https://www.instagram.com/beccapoppyhaigh/?g=5");
+
+        assertEquals("https://www.instagram.com/beccapoppyhaigh", MainWindow.getQueueListModel().get(0));
+    }
+}


### PR DESCRIPTION
### Motivation
- Prevent duplicate or noisy queue entries caused by Instagram tracking query parameters (for example `?g=5` or `?e=...&g=5`).
- Ensure URLs added to the queue are in a canonical form so ripper selection and duplicate detection behave consistently.

### Description
- Add `MainWindow.normalizeQueueUrl(String)` to canonicalize input URLs and strip query/fragment components for Instagram hosts while trimming trailing slashes. 
- Route queue insertions through normalization by updating `addUrlToQueue` to call `normalizeQueueUrl` before adding. 
- Apply normalization in the rip button handler (`RipButtonHandler.actionPerformed`) for both single URLs and expanded range URLs so duplicates from tracking variants are avoided. 
- Keep non-Instagram URLs unchanged and fall back to the original trimmed input for unparsable values.

### Testing
- Added unit tests in `MainWindowQueueUrlNormalizationTest` that verify Instagram tracking parameter removal, passthrough for non-Instagram URLs, and that `addUrlToQueue` stores the normalized Instagram URL. 
- Ran `./gradlew test --tests com.rarchives.ripme.ui.MainWindowQueueUrlNormalizationTest --tests com.rarchives.ripme.ui.MainWindowDomainQueueTest` and the tests completed successfully (build succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1125469cc832db0ef9d5c0ea422e0)