### PR TITLE
Normalize tracked URLs in queue/history and merge history duplicates

### DIFF
--- a/src/main/java/com/rarchives/ripme/ui/History.java
+++ b/src/main/java/com/rarchives/ripme/ui/History.java
@@ -9,7 +9,10 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Date;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
 
 import org.apache.commons.io.IOUtils;
 import org.json.JSONArray;
@@ -128,6 +131,39 @@ public class History {
             entry.url = item;
             list.add(entry);
         }
+    }
+
+    public void normalizeAndMergeUrls(Function<String, String> normalizer) {
+        Map<String, HistoryEntry> merged = new LinkedHashMap<>();
+        for (HistoryEntry entry : list) {
+            String normalizedUrl = normalizer.apply(entry.url);
+            if (normalizedUrl == null || normalizedUrl.isEmpty()) {
+                continue;
+            }
+            entry.url = normalizedUrl;
+            HistoryEntry existing = merged.get(normalizedUrl);
+            if (existing == null) {
+                merged.put(normalizedUrl, entry);
+                continue;
+            }
+            existing.count += entry.count;
+            existing.latestCount += entry.latestCount;
+            existing.selected = existing.selected || entry.selected;
+            if (existing.startDate.after(entry.startDate)) {
+                existing.startDate = entry.startDate;
+            }
+            if (existing.modifiedDate.before(entry.modifiedDate)) {
+                existing.modifiedDate = entry.modifiedDate;
+            }
+            if ((existing.title == null || existing.title.isEmpty()) && entry.title != null && !entry.title.isEmpty()) {
+                existing.title = entry.title;
+            }
+            if ((existing.dir == null || existing.dir.isEmpty()) && entry.dir != null && !entry.dir.isEmpty()) {
+                existing.dir = entry.dir;
+            }
+        }
+        list.clear();
+        list.addAll(merged.values());
     }
 
     private JSONArray toJSON() {

--- a/src/main/java/com/rarchives/ripme/ui/MainWindow.java
+++ b/src/main/java/com/rarchives/ripme/ui/MainWindow.java
@@ -23,6 +23,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Set;
 import java.util.Map;
@@ -511,7 +512,11 @@ public final class MainWindow implements Runnable, RipStatusHandler {
     }
 
     public static void addUrlToQueue(String url) {
-        queueListModel.addElement(normalizeQueueUrl(url));
+        String normalized = normalizeQueueUrl(url);
+        if (normalized == null || normalized.isEmpty() || queueListModel.contains(normalized)) {
+            return;
+        }
+        queueListModel.addElement(normalized);
     }
 
     static String normalizeQueueUrl(String rawUrl) {
@@ -537,10 +542,59 @@ public final class MainWindow implements Runnable, RipStatusHandler {
                         path, null, null).toURL();
                 return sanitized.toExternalForm();
             }
+            String strippedQuery = stripTrackingQueryParameters(parsed.getQuery());
+            if ((strippedQuery == null && parsed.getQuery() == null) || parsed.getQuery().equals(strippedQuery)) {
+                return trimmed;
+            }
+            URL sanitized = new URI(parsed.getProtocol(), parsed.getUserInfo(), parsed.getHost(), parsed.getPort(),
+                    parsed.getPath(), strippedQuery, null).toURL();
+            return sanitized.toExternalForm();
         } catch (URISyntaxException | MalformedURLException ignored) {
             // Fall back to original input for any unparsable values.
         }
         return trimmed;
+    }
+
+    private static String stripTrackingQueryParameters(String query) {
+        if (query == null || query.isEmpty()) {
+            return null;
+        }
+
+        Set<String> trackingKeys = new HashSet<>(Arrays.asList(
+                "fbclid", "gclid", "dclid", "yclid", "mc_cid", "mc_eid", "igshid", "ref", "ref_src"));
+        StringBuilder out = new StringBuilder();
+        for (String pair : query.split("&")) {
+            if (pair == null || pair.isEmpty()) {
+                continue;
+            }
+            int equalsIdx = pair.indexOf('=');
+            String key = equalsIdx >= 0 ? pair.substring(0, equalsIdx) : pair;
+            String loweredKey = key.toLowerCase(Locale.ROOT);
+            if (loweredKey.startsWith("utm_") || trackingKeys.contains(loweredKey)) {
+                continue;
+            }
+            if (out.length() > 0) {
+                out.append("&");
+            }
+            out.append(pair);
+        }
+        return out.length() == 0 ? null : out.toString();
+    }
+
+    private void normalizeAndDeduplicateQueue() {
+        LinkedHashMap<String, Object> normalized = new LinkedHashMap<>();
+        for (int i = 0; i < queueListModel.size(); i++) {
+            Object item = queueListModel.get(i);
+            String value = item == null ? null : item.toString();
+            String normalizedUrl = normalizeQueueUrl(value);
+            if (normalizedUrl != null && !normalizedUrl.isEmpty()) {
+                normalized.putIfAbsent(normalizedUrl, normalizedUrl);
+            }
+        }
+        queueListModel.clear();
+        for (Object value : normalized.values()) {
+            queueListModel.addElement(value);
+        }
     }
 
     public MainWindow() throws IOException {
@@ -975,8 +1029,9 @@ public final class MainWindow implements Runnable, RipStatusHandler {
                 JScrollPane.HORIZONTAL_SCROLLBAR_AS_NEEDED);
 
         for (String item : Utils.getConfigList("queue")) {
-            queueListModel.addElement(item);
+            addUrlToQueue(item);
         }
+        normalizeAndDeduplicateQueue();
         updateQueue();
 
         gbc.gridx = 0;
@@ -1610,7 +1665,7 @@ public final class MainWindow implements Runnable, RipStatusHandler {
             for (HistoryEntry entry : historySnapshot) {
                 if (entry.selected) {
                     added++;
-                    queueListModel.addElement(entry.url);
+                    addUrlToQueue(entry.url);
                 }
             }
             if (added == 0) {
@@ -1937,6 +1992,7 @@ public final class MainWindow implements Runnable, RipStatusHandler {
             try {
                 LOGGER.info(Utils.getLocalizedString("loading.history.from") + " " + historyFile.getCanonicalPath());
                 HISTORY.fromFile(historyFile.getCanonicalPath());
+                HISTORY.normalizeAndMergeUrls(MainWindow::normalizeQueueUrl);
                 HISTORY.sortByModifiedDateAscending();
             } catch (IOException e) {
                 LOGGER.error("Failed to load history from file " + historyFile, e);
@@ -1948,6 +2004,7 @@ public final class MainWindow implements Runnable, RipStatusHandler {
         } else {
             LOGGER.info(Utils.getLocalizedString("loading.history.from.configuration"));
             HISTORY.fromList(Utils.getConfigList("download.history"));
+            HISTORY.normalizeAndMergeUrls(MainWindow::normalizeQueueUrl);
             if (HISTORY.toList().isEmpty()) {
                 // Loaded from config, still no entries.
                 // Guess rip history based on rip folder
@@ -2079,7 +2136,7 @@ public final class MainWindow implements Runnable, RipStatusHandler {
                 status("Starting rip...");
                 ripper.setObserver(this);
 
-                String ripUrl = ripper.getURL().toExternalForm();
+                String ripUrl = normalizeQueueUrl(ripper.getURL().toExternalForm());
                 if (!HISTORY.containsURL(ripUrl)) {
                     HistoryEntry entry = new HistoryEntry();
                     entry.url = ripUrl;
@@ -2242,7 +2299,7 @@ public final class MainWindow implements Runnable, RipStatusHandler {
                         for (int i = rangeStart; i < rangeEnd + 1; i++) {
                             String realURL = normalizeQueueUrl(url.replaceAll("\\{\\S*\\}", Integer.toString(i)));
                             if (mainWindow.canRip(realURL)) {
-                                queueListModel.addElement(realURL);
+                                addUrlToQueue(realURL);
                                 ripTextfield.setText("");
                             } else {
                                 mainWindow.displayAndLogError("Can't find ripper for " + realURL, Color.RED);
@@ -2250,7 +2307,7 @@ public final class MainWindow implements Runnable, RipStatusHandler {
                         }
                     }
                 } else {
-                    queueListModel.addElement(url);
+                    addUrlToQueue(url);
                     ripTextfield.setText("");
                 }
             } else if (url_not_empty) {
@@ -2347,7 +2404,7 @@ public final class MainWindow implements Runnable, RipStatusHandler {
 
         case RIP_COMPLETE:
             RipStatusComplete rsc = (RipStatusComplete) msg.getObject();
-            String url = evt.ripper.getURL().toExternalForm();
+            String url = normalizeQueueUrl(evt.ripper.getURL().toExternalForm());
             HistoryEntry entry;
             if (HISTORY.containsURL(url)) {
                 entry = HISTORY.getEntryByURL(url);

--- a/src/test/java/com/rarchives/ripme/ui/HistoryNormalizationMergeTest.java
+++ b/src/test/java/com/rarchives/ripme/ui/HistoryNormalizationMergeTest.java
@@ -1,0 +1,44 @@
+package com.rarchives.ripme.ui;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Date;
+
+import org.junit.jupiter.api.Test;
+
+public class HistoryNormalizationMergeTest {
+
+    @Test
+    public void mergesEntriesThatNormalizeToSameUrl() {
+        History history = new History();
+
+        HistoryEntry first = new HistoryEntry();
+        first.url = "https://example.com/post?id=42&utm_source=twitter";
+        first.count = 7;
+        first.latestCount = 2;
+        first.startDate = new Date(1000);
+        first.modifiedDate = new Date(2000);
+        first.title = "Album";
+        first.dir = "/tmp/one";
+        history.add(first);
+
+        HistoryEntry second = new HistoryEntry();
+        second.url = "https://example.com/post?id=42&fbclid=abc";
+        second.count = 3;
+        second.latestCount = 1;
+        second.startDate = new Date(500);
+        second.modifiedDate = new Date(3000);
+        second.selected = true;
+        history.add(second);
+
+        history.normalizeAndMergeUrls(MainWindow::normalizeQueueUrl);
+
+        assertEquals(1, history.toList().size());
+        HistoryEntry merged = history.toList().get(0);
+        assertEquals("https://example.com/post?id=42", merged.url);
+        assertEquals(10, merged.count);
+        assertEquals(3, merged.latestCount);
+        assertEquals(new Date(500), merged.startDate);
+        assertEquals(new Date(3000), merged.modifiedDate);
+    }
+}

--- a/src/test/java/com/rarchives/ripme/ui/MainWindowQueueUrlNormalizationTest.java
+++ b/src/test/java/com/rarchives/ripme/ui/MainWindowQueueUrlNormalizationTest.java
@@ -26,6 +26,13 @@ public class MainWindowQueueUrlNormalizationTest {
     }
 
     @Test
+    public void stripsCommonTrackingParametersForNonInstagramUrls() {
+        assertEquals(
+                "https://example.com/post?id=42",
+                MainWindow.normalizeQueueUrl("https://example.com/post?id=42&utm_source=twitter&fbclid=abc"));
+    }
+
+    @Test
     public void addUrlToQueueStoresNormalizedInstagramUrl() throws IOException {
         MainWindow mainWindow = new MainWindow(true);
         MainWindow.getQueueListModel().clear();
@@ -33,5 +40,17 @@ public class MainWindowQueueUrlNormalizationTest {
         MainWindow.addUrlToQueue("https://www.instagram.com/beccapoppyhaigh/?g=5");
 
         assertEquals("https://www.instagram.com/beccapoppyhaigh", MainWindow.getQueueListModel().get(0));
+    }
+
+    @Test
+    public void addUrlToQueueDeduplicatesEquivalentUrls() throws IOException {
+        MainWindow mainWindow = new MainWindow(true);
+        MainWindow.getQueueListModel().clear();
+
+        MainWindow.addUrlToQueue("https://example.com/post?id=42&utm_source=twitter");
+        MainWindow.addUrlToQueue("https://example.com/post?id=42");
+
+        assertEquals(1, MainWindow.getQueueListModel().size());
+        assertEquals("https://example.com/post?id=42", MainWindow.getQueueListModel().get(0));
     }
 }


### PR DESCRIPTION
### Motivation
- Avoid duplicate queue/history entries caused by common tracking query parameters and preserve accurate download totals across runs. 
- Ensure Instagram links are treated as canonical (path-only) while stripping tracking params for other sites. 
- Prevent reintroduction of tracked variants when loading saved queue/history or when rips start/complete. 

### Description
- Normalize queue URLs by adding `normalizeQueueUrl` usage in `addUrlToQueue`, which now ignores empty inputs and avoids adding duplicates. 
- Strip common tracking parameters (e.g. `utm_*`, `fbclid`, `gclid`, etc.) via a new `stripTrackingQueryParameters` helper and keep Instagram URLs query-less. 
- Normalize and deduplicate the restored queue from config by calling `addUrlToQueue` when loading and running `normalizeAndDeduplicateQueue`. 
- Add `History.normalizeAndMergeUrls(Function<String,String>)` to canonicalize history URLs and merge entries that normalize to the same URL by summing `count` and `latestCount`, keeping earliest `startDate`, latest `modifiedDate`, and preserving title/dir/selected metadata. 
- Normalize rip URLs at rip start and completion so history updates use canonical URLs and do not fragment into tracked variants. 
- Tests added/updated: `MainWindowQueueUrlNormalizationTest` extended with tracking-stripping and dedupe checks, and new `HistoryNormalizationMergeTest` to validate history merging. 

### Testing
- Ran the targeted unit tests: `com.rarchives.ripme.ui.MainWindowQueueUrlNormalizationTest` and `com.rarchives.ripme.ui.HistoryNormalizationMergeTest`. 
- Tests initially identified an issue, which was fixed during this change; final test run `./gradlew test --tests com.rarchives.ripme.ui.MainWindowQueueUrlNormalizationTest --tests com.rarchives.ripme.ui.HistoryNormalizationMergeTest` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1191277d4832d907bb92dcad6ea59)