### PR TITLE
Normalize HTML-encoded and percent-encoded tracking params in queue/history URLs

### DIFF
--- a/src/main/java/com/rarchives/ripme/ui/MainWindow.java
+++ b/src/main/java/com/rarchives/ripme/ui/MainWindow.java
@@ -14,6 +14,8 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -523,7 +525,7 @@ public final class MainWindow implements Runnable, RipStatusHandler {
         if (rawUrl == null) {
             return null;
         }
-        String trimmed = rawUrl.trim();
+        String trimmed = rawUrl.trim().replace("&amp;", "&");
         if (trimmed.isEmpty()) {
             return trimmed;
         }
@@ -569,8 +571,12 @@ public final class MainWindow implements Runnable, RipStatusHandler {
             }
             int equalsIdx = pair.indexOf('=');
             String key = equalsIdx >= 0 ? pair.substring(0, equalsIdx) : pair;
+            if (key.startsWith("amp;")) {
+                key = key.substring(4);
+            }
             String loweredKey = key.toLowerCase(Locale.ROOT);
-            if (loweredKey.startsWith("utm_") || trackingKeys.contains(loweredKey)) {
+            String decodedKey = URLDecoder.decode(loweredKey, StandardCharsets.UTF_8).toLowerCase(Locale.ROOT);
+            if (decodedKey.startsWith("utm_") || trackingKeys.contains(decodedKey)) {
                 continue;
             }
             if (out.length() > 0) {

--- a/src/test/java/com/rarchives/ripme/ui/MainWindowQueueUrlNormalizationTest.java
+++ b/src/test/java/com/rarchives/ripme/ui/MainWindowQueueUrlNormalizationTest.java
@@ -30,6 +30,12 @@ public class MainWindowQueueUrlNormalizationTest {
         assertEquals(
                 "https://example.com/post?id=42",
                 MainWindow.normalizeQueueUrl("https://example.com/post?id=42&utm_source=twitter&fbclid=abc"));
+        assertEquals(
+                "https://example.com/post?id=42",
+                MainWindow.normalizeQueueUrl("https://example.com/post?id=42&amp;utm_source=twitter&amp;fbclid=abc"));
+        assertEquals(
+                "https://example.com/post?id=42",
+                MainWindow.normalizeQueueUrl("https://example.com/post?id=42&utm%5Fsource=twitter"));
     }
 
     @Test


### PR DESCRIPTION
### Motivation
- Links copied from HTML or other sources could include encoded ampersands (`&amp;`) or percent-encoded query keys which prevented the app from stripping tracking parameters, causing tracking params to appear in queue and history.

### Description
- Pre-normalize queue input by replacing HTML-encoded ampersands (`&amp;`) before URL parsing in `MainWindow.normalizeQueueUrl`.
- Harden query-key stripping in `MainWindow.stripTrackingQueryParameters` to handle keys prefixed with `amp;` and to detect percent-encoded tracking keys by `URLDecoder.decode(..., UTF_8)` prior to matching `utm_` and known tracking keys.
- Added unit tests in `MainWindowQueueUrlNormalizationTest` that assert normalization of `&amp;` separators and percent-encoded tracking keys (e.g. `utm%5Fsource`).
- Minor import additions: `URLDecoder` and `StandardCharsets` in `MainWindow.java`.

### Testing
- Ran targeted unit tests with `./gradlew test --tests com.rarchives.ripme.ui.MainWindowQueueUrlNormalizationTest --tests com.rarchives.ripme.ui.HistoryNormalizationMergeTest`, which completed successfully (BUILD SUCCESSFUL).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f11b7bd938832dade0adf9a3b47368)