### PR TITLE
Add queue pause toggle to prevent starting new queued rips

### DIFF
--- a/src/main/java/com/rarchives/ripme/ui/MainWindow.java
+++ b/src/main/java/com/rarchives/ripme/ui/MainWindow.java
@@ -79,6 +79,7 @@ public final class MainWindow implements Runnable, RipStatusHandler {
 
     /* not static! */
     private boolean isRipping = false; // Flag to indicate if we're ripping something
+    private volatile boolean queuePaused = false;
     private final Map<AbstractRipper, ActiveDownloadEntry> activeRippers = new ConcurrentHashMap<>();
     private final Set<String> activeDomains = Collections.newSetFromMap(new ConcurrentHashMap<>());
     private final ExecutorService ripExecutor = Executors.newCachedThreadPool();
@@ -118,7 +119,7 @@ public final class MainWindow implements Runnable, RipStatusHandler {
     private static DefaultListModel<Object> queueListModel;
     private static JList<Object> queueList;
     private static QueueMenuMouseListener queueMenuMouseListener;
-    private static JButton queueButtonTop, queueButtonUp, queueButtonDown;
+    private static JButton queueButtonTop, queueButtonUp, queueButtonDown, queuePauseButton;
 
     // Active downloads
     private static JButton optionActive;
@@ -195,6 +196,20 @@ public final class MainWindow implements Runnable, RipStatusHandler {
 
     private void updateQueue() {
         updateQueue(null);
+    }
+
+    private void updateQueuePauseButtonLabel() {
+        if (queuePauseButton != null) {
+            queuePauseButton.setText(Utils.getLocalizedString(queuePaused ? "queue.resume" : "queue.pause"));
+        }
+    }
+
+    synchronized void setQueuePaused(boolean paused) {
+        queuePaused = paused;
+        updateQueuePauseButtonLabel();
+        if (!queuePaused) {
+            ripNextAlbum();
+        }
     }
 
     private static void applyHistoryFilter() {
@@ -635,6 +650,8 @@ public final class MainWindow implements Runnable, RipStatusHandler {
         queueListModel = new DefaultListModel<>();
         queueList = new JList<>(queueListModel);
         optionQueue = new JButton(Utils.getLocalizedString("queue"));
+        queuePauseButton = new JButton();
+        updateQueuePauseButtonLabel();
         stopButton = new JButton();
         pauseButton = new JButton();
         statusProgress = new JProgressBar();
@@ -1120,6 +1137,11 @@ public final class MainWindow implements Runnable, RipStatusHandler {
         queueButtonPanel.add(queueButtonUp, buttonGbc);
         buttonGbc.gridy = 2;
         queueButtonPanel.add(queueButtonDown, buttonGbc);
+        buttonGbc.gridy = 3;
+        queuePauseButton = new JButton();
+        updateQueuePauseButtonLabel();
+        queuePauseButton.addActionListener(e -> setQueuePaused(!queuePaused));
+        queueButtonPanel.add(queuePauseButton, buttonGbc);
 
         queueGbc.gridx = 1;
         queueGbc.weightx = 0;
@@ -2040,6 +2062,12 @@ public final class MainWindow implements Runnable, RipStatusHandler {
     }
 
     synchronized void ripNextAlbum() {
+        if (queuePaused) {
+            LOGGER.debug("Queue is paused; no queued items will be started");
+            isRipping = !activeDomains.isEmpty();
+            return;
+        }
+
         // Save current state of queue to configuration.
         Utils.setConfigList("queue", queueListModel.elements());
 
@@ -2226,6 +2254,10 @@ public final class MainWindow implements Runnable, RipStatusHandler {
 
     Set<String> getActiveDomains() {
         return activeDomains;
+    }
+
+    boolean isQueuePaused() {
+        return queuePaused;
     }
 
     private static final class RipperRun {

--- a/src/main/resources/LabelsBundle.properties
+++ b/src/main/resources/LabelsBundle.properties
@@ -36,6 +36,8 @@ queue.remove.selected = Remove Selected
 queue.move.top = Move to Top
 queue.move.up = Move Up
 queue.move.down = Move Down
+queue.pause = Pause queue
+queue.resume = Resume queue
 
 # Active downloads
 active.downloads = Active downloads

--- a/src/test/java/com/rarchives/ripme/ui/MainWindowQueuePauseTest.java
+++ b/src/test/java/com/rarchives/ripme/ui/MainWindowQueuePauseTest.java
@@ -1,0 +1,38 @@
+package com.rarchives.ripme.ui;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.swing.DefaultListModel;
+
+import org.junit.jupiter.api.Test;
+
+public class MainWindowQueuePauseTest {
+
+    @Test
+    public void pausedQueueDoesNotStartUntilResumed() throws IOException {
+        MainWindow mainWindow = new MainWindow(true);
+
+        DefaultListModel<Object> queue = MainWindow.getQueueListModel();
+        queue.clear();
+        mainWindow.getActiveDomains().clear();
+
+        AtomicInteger startedCount = new AtomicInteger(0);
+        mainWindow.setRipperLauncher((url, domain) -> startedCount.incrementAndGet());
+
+        queue.addElement("http://example.com/first");
+        mainWindow.setQueuePaused(true);
+
+        mainWindow.ripNextAlbum();
+        assertTrue(mainWindow.isQueuePaused(), "Queue should remain paused");
+        assertEquals(0, startedCount.get(), "No queued rip should start while paused");
+        assertEquals(1, queue.getSize(), "Queue items should remain queued while paused");
+
+        mainWindow.setQueuePaused(false);
+        assertEquals(1, startedCount.get(), "Queued rip should start once queue is resumed");
+        assertEquals(0, queue.getSize(), "Queue should drain after resume");
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a way to pause the dispatching of queued downloads so no new rips are started while performing updates or maintenance.

### Description
- Introduced a `queuePaused` flag and `setQueuePaused(boolean)` in `MainWindow` to control queue dispatch and immediately resume dispatch when unpaused.
- Added a `queuePauseButton` UI control next to queue ordering buttons and a helper `updateQueuePauseButtonLabel()` to toggle the button text using new localization keys.
- Short-circuited `ripNextAlbum()` to return early while the queue is paused so active downloads continue but no new queued items are started.
- Initialized the pause button in headless mode for tests and exposed `isQueuePaused()` for assertions.
- Added localization keys `queue.pause` and `queue.resume` to `LabelsBundle.properties` and added unit test `MainWindowQueuePauseTest` to verify pause/resume behavior.

### Testing
- Ran targeted unit tests: `./gradlew test --tests com.rarchives.ripme.ui.MainWindowQueuePauseTest --tests com.rarchives.ripme.ui.MainWindowDomainQueueTest` and the build completed successfully (`BUILD SUCCESSFUL`).
- The new test `MainWindowQueuePauseTest` verifies that queued items are not started while paused and that they start once unpaused. All automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f11ce7cecc832dbc2ff9343d14ef10)