### PR TITLE
Increase Instagram rate-limit retry initial delay to 32000 ms

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/InstagramRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/InstagramRipper.java
@@ -37,6 +37,7 @@ import java.sql.Statement;
 public class InstagramRipper extends AbstractJSONRipper {
     private static final Logger logger = LogManager.getLogger(InstagramRipper.class);
     private static final int WAIT_TIME = 2000;
+    private static final int RATE_LIMIT_WAIT_TIME = 32000;
     private static final int TIMEOUT = 20000;
     private static final int MAX_RATE_LIMIT_RETRIES = 6;
     private String csrftoken = null;
@@ -419,7 +420,8 @@ public class InstagramRipper extends AbstractJSONRipper {
                 lastException = e;
 
                 boolean isRateLimit = e instanceof HttpStatusException && ((HttpStatusException) e).getStatusCode() == 429;
-                long waitMillis = WAIT_TIME * (1L << (attempt - 1));
+                long initialWait = isRateLimit ? RATE_LIMIT_WAIT_TIME : WAIT_TIME;
+                long waitMillis = initialWait * (1L << (attempt - 1));
 
                 if (attempt < MAX_RATE_LIMIT_RETRIES && (isRateLimit || !(e instanceof HttpStatusException))) {
                     if (isRateLimit) {


### PR DESCRIPTION
### Motivation
- Instagram HTTP 429 (rate-limited) responses were being retried from a small base delay and empirically require a much longer initial wait, so start rate-limit backoff at 32000 ms to reduce pointless rapid retries.

### Description
- Added `RATE_LIMIT_WAIT_TIME = 32000` to `InstagramRipper.java` and updated the retry backoff in `executeInstagramApiRequest` to use `RATE_LIMIT_WAIT_TIME` as the initial wait for 429 responses, while keeping `WAIT_TIME = 2000` for other I/O errors and applying exponential backoff from the selected initial wait.

### Testing
- Ran `./gradlew test --tests InstagramRipperLimitTest` and the test run completed successfully (build successful).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f123b6d02c832da5fb5ed1796114bc)