### PR TITLE
Retry transient 5xx responses in Http.getWith429Retry

### DIFF
--- a/src/main/java/com/rarchives/ripme/utils/Http.java
+++ b/src/main/java/com/rarchives/ripme/utils/Http.java
@@ -267,6 +267,20 @@ public class Http {
                 }
             }
 
+            if (responseCode >= 500 && responseCode <= 599) {
+                if (retries < maxRetries) {
+                    long waitTime = calculate429WaitSeconds(retries, baseDelaySeconds, maxDelaySeconds, null, random);
+                    logger.warn("[!] HTTP {} from {} - retrying in {}s (attempt {}/{})",
+                            responseCode, url, waitTime, retries + 1, maxRetries);
+                    Utils.sleep(waitTime * 1000L);
+                    retries++;
+                    continue;
+                } else {
+                    logger.warn("[!] HTTP {} from {} after {} retries - failing request",
+                            responseCode, url, maxRetries);
+                }
+            }
+
             if (responseCode >= 400) {
                 throw new HttpStatusException("HTTP error fetching URL", responseCode, url.toString());
             }


### PR DESCRIPTION
### Motivation
- Reddit user JSON endpoints can intermittently return HTTP 500/5xx responses which previously caused immediate rip failure, so server-side transient errors should be retried similarly to 429 rate-limits.

### Description
- Update `src/main/java/com/rarchives/ripme/utils/Http.java` to treat HTTP 5xx responses as transient and retry up to `maxRetries` using the existing jittered backoff via `calculate429WaitSeconds` and `Utils.sleep` with informative logging. 
- Preserve existing behavior for 4xx errors by throwing `HttpStatusException` after retries are exhausted and keep the public API/behavior of `getWith429Retry` unchanged. 

### Testing
- Ran `./gradlew compileJava` which completed successfully (BUILD SUCCESSFUL) with compilation warnings. 
- No additional automated tests were added or modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b585aaf7c832d950dadd69cde0d6f)