### PR TITLE
Facebook ripper: retry via mbasic host when main host returns HTTP 400

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/FacebookRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/FacebookRipper.java
@@ -5,6 +5,7 @@ import com.rarchives.ripme.utils.FirefoxCookieUtils;
 import com.rarchives.ripme.utils.Http;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.jsoup.HttpStatusException;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
@@ -76,15 +77,35 @@ public class FacebookRipper extends AbstractHTMLRipper {
         Http request = Http.url(this.url).userAgent(USER_AGENT).referrer("https://www.facebook.com/").ignoreContentType();
         if (!facebookCookies.isEmpty()) {
             request.cookies(facebookCookies);
-            if (facebookCookies.containsKey("c_user")) {
-                request.header("X-Requested-With", "XMLHttpRequest");
+        }
+
+        String body;
+        try {
+            body = request.get().html();
+        } catch (HttpStatusException ex) {
+            if (ex.getStatusCode() == 400) {
+                URL fallback = toMbasicUrl(this.url);
+                logger.warn("Facebook returned HTTP 400 for {}, retrying with {}", this.url, fallback);
+                Http fallbackRequest = Http.url(fallback).userAgent(USER_AGENT).referrer("https://mbasic.facebook.com/").ignoreContentType();
+                if (!facebookCookies.isEmpty()) {
+                    fallbackRequest.cookies(facebookCookies);
+                }
+                body = fallbackRequest.get().html();
+            } else {
+                throw ex;
             }
         }
-        String body = request.get().html();
         if (body == null || body.isBlank()) {
             throw new IOException("Facebook returned an empty response");
         }
         return Jsoup.parse(body, this.url.toExternalForm());
+    }
+
+    private URL toMbasicUrl(URL source) throws MalformedURLException {
+        String target = source.toExternalForm()
+                .replaceFirst("(?i)://(?:www\\.|m\\.)?facebook\\.com", "://mbasic.facebook.com")
+                .replaceFirst("(?i)://(?:www\\.)?fb\\.com", "://mbasic.facebook.com");
+        return new URL(target);
     }
 
     @Override


### PR DESCRIPTION
### Motivation
- Facebook profile/reels pages sometimes return HTTP 400 when requested from the standard web host, causing rip failures as shown by repeated `Status=400` errors in logs. 
- The `mbasic.facebook.com` host often serves simpler HTML that is still parseable for media extraction and can succeed where the main host fails. 
- Reducing request fingerprints (removing the conditional `X-Requested-With` header) can avoid triggering stricter responses from Facebook.

### Description
- Added `HttpStatusException` handling in `FacebookRipper#getFirstPage` to catch HTTP 400 responses and retry once against a converted `mbasic.facebook.com` URL. 
- Introduced a helper `toMbasicUrl(URL)` to map `facebook.com` / `fb.com` URLs to the `mbasic.facebook.com` host for the fallback request. 
- Removed the conditional addition of the `X-Requested-With: XMLHttpRequest` header and simplified cookie application to reduce request fingerprinting while keeping cookie loading intact. 
- Kept user-agent, referrer and cookie behavior for both primary and fallback requests to preserve authentication when available.

### Testing
- Ran `./gradlew -q compileJava` and the project compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15f6655504832db0505fbff723b7ad)