### PR TITLE
FacebookRipper: add robust fetch fallbacks with mobile/mbasic variants and request headers

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/FacebookRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/FacebookRipper.java
@@ -74,37 +74,68 @@ public class FacebookRipper extends AbstractHTMLRipper {
     @Override
     protected Document getFirstPage() throws IOException {
         loadFacebookCookies();
-        Http request = Http.url(this.url).userAgent(USER_AGENT).referrer("https://www.facebook.com/").ignoreContentType();
-        if (!facebookCookies.isEmpty()) {
-            request.cookies(facebookCookies);
-        }
-
-        String body;
-        try {
-            body = request.get().html();
-        } catch (HttpStatusException ex) {
-            if (ex.getStatusCode() == 400) {
-                URL fallback = toMbasicUrl(this.url);
-                logger.warn("Facebook returned HTTP 400 for {}, retrying with {}", this.url, fallback);
-                Http fallbackRequest = Http.url(fallback).userAgent(USER_AGENT).referrer("https://mbasic.facebook.com/").ignoreContentType();
-                if (!facebookCookies.isEmpty()) {
-                    fallbackRequest.cookies(facebookCookies);
-                }
-                body = fallbackRequest.get().html();
-            } else {
-                throw ex;
-            }
-        }
+        String body = fetchWithFallbacks();
         if (body == null || body.isBlank()) {
             throw new IOException("Facebook returned an empty response");
         }
         return Jsoup.parse(body, this.url.toExternalForm());
     }
 
+    private String fetchWithFallbacks() throws IOException {
+        List<URL> candidates = Arrays.asList(this.url, toMobileUrl(this.url), toMbasicUrl(this.url));
+        List<String> referrers = Arrays.asList("https://www.facebook.com/", "https://m.facebook.com/", "https://mbasic.facebook.com/");
+        HttpStatusException last400 = null;
+
+        for (int i = 0; i < candidates.size(); i++) {
+            URL candidate = candidates.get(i);
+            Http request = newFacebookRequest(candidate, referrers.get(i));
+            if (!facebookCookies.isEmpty()) {
+                request.cookies(facebookCookies);
+            }
+            try {
+                return request.get().html();
+            } catch (HttpStatusException ex) {
+                if (ex.getStatusCode() == 400 && i < candidates.size() - 1) {
+                    logger.warn("Facebook returned HTTP 400 for {}, retrying with {}", candidate, candidates.get(i + 1));
+                    last400 = ex;
+                    continue;
+                }
+                throw ex;
+            }
+        }
+
+        if (last400 != null) {
+            throw last400;
+        }
+        throw new IOException("Failed to load Facebook page from all fallback URLs");
+    }
+
+    private Http newFacebookRequest(URL targetUrl, String referrer) {
+        return Http.url(targetUrl)
+                .userAgent(USER_AGENT)
+                .referrer(referrer)
+                .ignoreContentType()
+                .header("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8")
+                .header("Accept-Language", "en-US,en;q=0.9")
+                .header("Cache-Control", "no-cache")
+                .header("Pragma", "no-cache")
+                .header("Sec-Fetch-Dest", "document")
+                .header("Sec-Fetch-Mode", "navigate")
+                .header("Sec-Fetch-Site", "same-origin")
+                .header("Upgrade-Insecure-Requests", "1");
+    }
+
     private URL toMbasicUrl(URL source) throws MalformedURLException {
         String target = source.toExternalForm()
                 .replaceFirst("(?i)://(?:www\\.|m\\.)?facebook\\.com", "://mbasic.facebook.com")
                 .replaceFirst("(?i)://(?:www\\.)?fb\\.com", "://mbasic.facebook.com");
+        return new URL(target);
+    }
+
+    private URL toMobileUrl(URL source) throws MalformedURLException {
+        String target = source.toExternalForm()
+                .replaceFirst("(?i)://(?:www\\.|mbasic\\.)?facebook\\.com", "://m.facebook.com")
+                .replaceFirst("(?i)://(?:www\\.)?fb\\.com", "://m.facebook.com");
         return new URL(target);
     }
 


### PR DESCRIPTION
### Motivation
- Improve resilience when loading Facebook pages by trying alternate URL variants and handling HTTP 400 responses.
- Provide more realistic request headers and referrers to reduce server-side blocking and better mimic browser requests.
- Normalize loading logic and centralize request creation for easier future tweaks and debugging.

### Description
- Replaced inline fetch logic in `getFirstPage()` with `fetchWithFallbacks()` which tries `www`, `m`, and `mbasic` URL variants and retries on HTTP 400 responses before failing.
- Added `toMobileUrl()` helper and reused existing `toMbasicUrl()` to generate fallback candidate URLs.
- Introduced `newFacebookRequest()` to centralize request headers, user agent, referrer, and `ignoreContentType()` settings and to attach stored `facebookCookies` where present.
- Improved error handling to rethrow the final `HttpStatusException` for repeated 400 responses and to return a parsed `Document` only when a non-empty body is retrieved.

### Testing
- Ran the project unit test suite with `mvn test`, and all tests completed successfully.
- Performed a fetch verification by loading a public Facebook page through the updated `fetchWithFallbacks()` logic, which returned a non-empty HTML `Document` and extracted expected meta media entries.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a171d5df684832d8eda71c822b3a4d9)