### PR TITLE
Fix Facebook media URL entity decoding

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/FacebookRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/FacebookRipper.java
@@ -7,6 +7,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jsoup.HttpStatusException;
 import org.jsoup.Jsoup;
+import org.jsoup.parser.Parser;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 
@@ -181,7 +182,8 @@ public class FacebookRipper extends AbstractHTMLRipper {
         if (value == null) {
             return null;
         }
-        return value.replace("\\u0025", "%")
+        return Parser.unescapeEntities(value, false)
+                .replace("\\u0025", "%")
                 .replace("\\u0026", "&")
                 .replace("\\/", "/")
                 .replace("\\u003D", "=")

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/FacebookRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/FacebookRipperTest.java
@@ -1,0 +1,37 @@
+package com.rarchives.ripme.tst.ripper.rippers;
+
+import com.rarchives.ripme.ripper.rippers.FacebookRipper;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.junit.jupiter.api.Test;
+
+import java.net.URL;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class FacebookRipperTest {
+
+    private static class TestableFacebookRipper extends FacebookRipper {
+        TestableFacebookRipper(URL url) throws java.io.IOException {
+            super(url);
+        }
+
+        List<String> extract(Document doc) throws java.io.UnsupportedEncodingException {
+            return super.getURLsFromPage(doc);
+        }
+    }
+
+    @Test
+    public void testExtractedMediaUrlsDecodeHtmlAmpersands() throws Exception {
+        String html = "<html><head>"
+                + "<meta property=\"og:image\" content=\"https://scontent.xx.fbcdn.net/file.jpg?foo=1&amp;bar=2\">"
+                + "</head><body></body></html>";
+        Document doc = Jsoup.parse(html, "https://www.facebook.com/example/posts/1");
+
+        TestableFacebookRipper ripper = new TestableFacebookRipper(new URL("https://www.facebook.com/example/posts/1"));
+        List<String> urls = ripper.extract(doc);
+
+        assertTrue(urls.contains("https://scontent.xx.fbcdn.net/file.jpg?foo=1&bar=2"));
+    }
+}


### PR DESCRIPTION
### Motivation
- Facebook media URLs embedded in pages are HTML-encoded (e.g. `&amp;`) which can leave query parameters malformed and cause CDN 403s when downloaded. 
- The ripper should decode HTML entities before normalizing JSON-escaped characters so discovered URLs are requested in their real form.

### Description
- Update `unescapeJsonUrl` in `src/main/java/com/rarchives/ripme/ripper/rippers/FacebookRipper.java` to call `Parser.unescapeEntities(value, false)` before applying existing JSON-style replacements. 
- Add the `org.jsoup.parser.Parser` import required for entity decoding. 
- Add a focused unit test `src/test/java/com/rarchives/ripme/tst/ripper/rippers/FacebookRipperTest.java` that verifies an `og:image` meta tag containing `&amp;` is extracted as a URL with `&`.

### Testing
- Ran the targeted test with `./gradlew test --tests com.rarchives.ripme.tst.ripper.rippers.FacebookRipperTest` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1722039bd0832dbb0e164f7b3a914d)