### PR TITLE
Fix Reddit DASH direct video URL resolution

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/RedditRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/RedditRipper.java
@@ -618,10 +618,12 @@ public class RedditRipper extends AlbumRipper {
     }
 
     private URL parseRedditVideoMPD(String vidURL) {
-        // Some Reddit API responses already contain a direct CMAF mp4 URL.
-        // In that case we can download the file directly instead of trying to
-        // resolve a DASH manifest from a non-container path.
-        if (vidURL.matches("^https?://v\\.redd\\.it/.+\\.mp4($|\\?.*)")) {
+        String manifestBaseUrl = vidURL;
+        // Reddit can return direct URLs like /DASH_720.mp4 where the requested
+        // rendition no longer exists. Resolve those from DASHPlaylist.mpd.
+        if (vidURL.matches("^https?://v\\.redd\\.it/[^/]+/DASH_[^/?]+\\.mp4($|\\?.*)")) {
+            manifestBaseUrl = vidURL.substring(0, vidURL.lastIndexOf('/'));
+        } else if (vidURL.matches("^https?://v\\.redd\\.it/.+\\.mp4($|\\?.*)")) {
             try {
                 return new URI(vidURL).toURL();
             } catch (MalformedURLException | URISyntaxException e) {
@@ -632,7 +634,7 @@ public class RedditRipper extends AlbumRipper {
 
         org.jsoup.nodes.Document doc;
         try {
-            doc = Http.url(vidURL + "/DASHPlaylist.mpd").ignoreContentType().get();
+            doc = Http.url(manifestBaseUrl + "/DASHPlaylist.mpd").ignoreContentType().get();
             int largestHeight = 0;
             String baseURL = null;
             // Loops over all the videos and finds the one with the largest height and sets baseURL to the base url of that video
@@ -646,7 +648,7 @@ public class RedditRipper extends AlbumRipper {
                     baseURL = doc.select("MPD > Period > AdaptationSet > Representation[height=" + height + "]").select("BaseURL").text();
                 }
             }
-            return new URI(vidURL + "/" + baseURL).toURL();
+            return new URI(manifestBaseUrl + "/" + baseURL).toURL();
         } catch (IOException | URISyntaxException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
### Motivation
- Reddit sometimes returns direct `v.redd.it/.../DASH_*.mp4` URLs that point to a specific rendition which may no longer exist, causing downloads to fail.
- The ripper should resolve the best available rendition from the post's DASH manifest instead of blindly attempting to download the possibly-missing fixed DASH file.

### Description
- Update `parseRedditVideoMPD` to detect `v.redd.it/.../DASH_*.mp4` direct links and use the parent path as `manifestBaseUrl` to fetch `DASHPlaylist.mpd`.
- Select the representation with the largest `height` from the MPD and build the download URL using `manifestBaseUrl` plus the `BaseURL` from the manifest.
- Preserve existing behavior for other direct mp4 URLs (including CMAF-style links) by returning them directly when appropriate.

### Testing
- Ran `./gradlew test --tests com.rarchives.ripme.ripper.rippers.RedditRipperTest`, which initially failed due to a regex/logic mismatch causing a `NullPointerException` during the first run.
- After adjusting the detection logic, re-ran `./gradlew test --tests com.rarchives.ripme.ripper.rippers.RedditRipperTest` and the targeted tests completed successfully and the build was `BUILD SUCCESSFUL`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a172284fd60832db260c225a12ded00)