### PR TITLE
Handle failing v.redd.it CMAF downloads with DASH fallback

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/RedditRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/RedditRipper.java
@@ -625,8 +625,28 @@ public class RedditRipper extends AlbumRipper {
             manifestBaseUrl = vidURL.substring(0, vidURL.lastIndexOf('/'));
         } else if (vidURL.matches("^https?://v\\.redd\\.it/.+\\.mp4($|\\?.*)")) {
             try {
-                return new URI(vidURL).toURL();
-            } catch (MalformedURLException | URISyntaxException e) {
+                URL directUrl = new URI(vidURL).toURL();
+                if (!vidURL.contains("/CMAF_")) {
+                    return directUrl;
+                }
+                // CMAF renditions can intermittently 403/404 even when the post is still
+                // available. Validate first, then fall back to DASHPlaylist.mpd if needed.
+                int status = Http.url(directUrl)
+                        .ignoreHttpErrors()
+                        .ignoreContentType()
+                        .timeout(10_000)
+                        .connection()
+                        .execute()
+                        .statusCode();
+                if (status >= 200 && status < 300) {
+                    return directUrl;
+                }
+                logger.info("Direct Reddit video URL {} returned HTTP {}, falling back to DASH playlist", vidURL, status);
+                manifestBaseUrl = vidURL.substring(0, vidURL.lastIndexOf('/'));
+            } catch (IOException | URISyntaxException e) {
+                logger.info("Unable to fetch direct Reddit video URL {}, falling back to DASH playlist: {}", vidURL, e.getMessage());
+                manifestBaseUrl = vidURL.substring(0, vidURL.lastIndexOf('/'));
+            } catch (IllegalArgumentException e) {
                 logger.warn("Unable to parse direct Reddit video URL {}: {}", vidURL, e.getMessage());
                 return null;
             }

--- a/src/test/java/com/rarchives/ripme/ripper/rippers/RedditRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/ripper/rippers/RedditRipperTest.java
@@ -79,14 +79,14 @@ class RedditRipperTest {
     }
 
     @Test
-    void parsesDirectRedditCmafVideoUrlWithoutManifestLookup() throws Exception {
+    void parsesDirectRedditVideoUrlWithoutManifestLookup() throws Exception {
         RedditRipper ripper = new RedditRipper(new URL("https://www.reddit.com/r/test"));
         Method parseRedditVideoMPD = RedditRipper.class.getDeclaredMethod("parseRedditVideoMPD", String.class);
         parseRedditVideoMPD.setAccessible(true);
 
-        URL parsed = (URL) parseRedditVideoMPD.invoke(ripper, "https://v.redd.it/hdohowvhfslg1/CMAF_360.mp4");
+        URL parsed = (URL) parseRedditVideoMPD.invoke(ripper, "https://v.redd.it/hdohowvhfslg1/fallback.mp4");
 
-        assertEquals("https://v.redd.it/hdohowvhfslg1/CMAF_360.mp4", parsed.toExternalForm());
+        assertEquals("https://v.redd.it/hdohowvhfslg1/fallback.mp4", parsed.toExternalForm());
     }
 
     private DownloadLimitTracker downloadLimitTrackerOf(RedditRipper ripper) throws Exception {


### PR DESCRIPTION
### Motivation
- Some Reddit posts expose `v.redd.it` CMAF renditions (`CMAF_*.mp4`) that intermittently return non-2xx responses even though the post is viewable, causing downloads to fail. 

### Description
- For direct `v.redd.it` MP4 URLs, preserve the existing fast path by returning the direct URL immediately when it is not a CMAF rendition. 
- For `CMAF_*.mp4` URLs, probe the direct URL with an HTTP request and, if the response is not 2xx (or the probe fails), fall back to resolving a playable rendition from `DASHPlaylist.mpd`. 
- Keep existing DASH/DASHPlaylist resolution logic intact for the fallback path. 
- Update the unit test `RedditRipperTest` to assert the preserved direct-MP4 behavior for a non-CMAF URL. 
- Modified files: `src/main/java/com/rarchives/ripme/ripper/rippers/RedditRipper.java` and `src/test/java/com/rarchives/ripme/ripper/rippers/RedditRipperTest.java`.

### Testing
- Ran the targeted unit tests with `./gradlew test --tests com.rarchives.ripme.ripper.rippers.RedditRipperTest --no-daemon`. 
- Result: tests completed successfully (PASS).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a172624b4f8832d9ac6dec02037e392)